### PR TITLE
Fix bug where appointments would end up one day prior

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -38,7 +38,7 @@ module.exports = {
     daysBeforeToday: 12,
     historicPeriodCount: 1, // Number of historic periods to generate
 
-    simulatedTime: '11:30', // 24h format
+    simulatedTime: '10:30', // 24h format
   },
   reading: {
     blindReading: 'true', // Enable blind reading

--- a/app/lib/generators/clinic-generator.js
+++ b/app/lib/generators/clinic-generator.js
@@ -43,9 +43,9 @@ const generateTimeSlots = (date, sessionTimes, clinicType) => {
   const isToday = clinicDate.isSame(today)
 
   const slots = []
-  const startTime = new Date(`${date.toISOString().split('T')[0]}T${sessionTimes.startTime}`)
-  const endTime = new Date(`${date.toISOString().split('T')[0]}T${sessionTimes.endTime}`)
-
+  const dateStr = dayjs(date).format('YYYY-MM-DD')
+  const startTime = dayjs(`${dateStr}T${sessionTimes.startTime}`).toDate()
+  const endTime = dayjs(`${dateStr}T${sessionTimes.endTime}`).toDate()
   const currentTime = new Date(startTime)
 
   // Calculate how many slots should be double-booked

--- a/app/lib/utils/clinics.js
+++ b/app/lib/utils/clinics.js
@@ -9,8 +9,8 @@ const config = require('../../config')
  * @param {Array} clinics - Array of all clinics
  */
 const getTodaysClinics = (clinics) => {
-  const today = new Date().toISOString().split('T')[0]
-  return clinics.filter(c => c.date === today)
+  const today = dayjs().startOf('day')
+  return clinics.filter(c => dayjs(c.date).isSame(today, 'day'))
 }
 
 /**


### PR DESCRIPTION
Appointments/events within a clinic were ending up scheduled one day prior to the clinic.

This is likely caused by poor date handling where the prototype got the date of the current clinic and ended up with a time of 11pm the day before. Fixed by using day.js for date handling more consistently.