### PR TITLE
Add outcome column to history section

### DIFF
--- a/app/views/dashboard.html
+++ b/app/views/dashboard.html
@@ -30,6 +30,15 @@
     }) }}
   </li>
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
+    {{ card({
+      clickable: true,
+      heading: "Image reading",
+      headingClasses: "nhsuk-heading-m",
+      href: "/reading",
+      descriptionHtml: false
+    }) }}
+  </li>
+  <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
 
     {% set participantCardDescriptionHtml %}
       <p>72k participants registered</p>
@@ -42,15 +51,7 @@
       descriptionHtml: participantCardDescriptionHtml
     }) }}
   </li>
-  <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    {{ card({
-      clickable: true,
-      heading: "Messages",
-      headingClasses: "nhsuk-heading-m",
-      href: "#",
-      descriptionHtml: false
-    }) }}
-  </li>
+
 </ul>
 
 

--- a/app/views/reading/history.html
+++ b/app/views/reading/history.html
@@ -55,6 +55,9 @@
               Opinon
             {% endif %}
           </th>
+          <th scope="col">
+            Outcome
+          </th>
         </tr>
       </thead>
       <tbody class="nhsuk-table__body">
@@ -96,6 +99,23 @@
             </td>
             <td>
               {{ reading.result | toTag }}
+            </td>
+            <td>
+              {% set event = data.events | find('id', reading.eventId) %}
+              {% set metadata = event | getReadingMetadata %}
+              {{ metadata | log("metadata")}}
+              {% if metadata.readCount >= 2 %}
+                {% if metadata.hasDisagreement %}
+                  {{ "Arbitration" | toTag }}
+                {% else %}
+                  {% set result = metadata.reads[0].result %}
+                  {{ result | toTag }}
+                {% endif %}
+              {% elif metadata.readCount == 1 %}
+                {{ "Waiting for 2nd read" | toTag }}
+              {% else %}
+                {{ "Waiting for 1st read" | toTag }}
+              {% endif %}
             </td>
           </tr>
         {% endfor %}


### PR DESCRIPTION
Adds an extra column to the history section to show the outcome of a case.

<img width="1097" alt="Screenshot 2025-04-23 at 16 31 33" src="https://github.com/user-attachments/assets/898a9ceb-d5a6-46e9-be5a-2714a984ee08" />
