### PR TITLE
Make first clinic of today and events for test scenarios predictable

### DIFF
--- a/app/data/test-scenarios.js
+++ b/app/data/test-scenarios.js
@@ -21,6 +21,7 @@ module.exports = [
       },
       extraNeeds: ['Wheelchair user'],
       config: {
+        eventId: '5gpn41oi',
         defaultRiskLevel: 'routine',
         repeatViews: ['RMLO'],
         missingViews: [], // ensure all views are present
@@ -45,6 +46,7 @@ module.exports = [
       },
       extraNeeds: null,
       config: {
+        eventId: '0gdof6fh',
         defaultRiskLevel: 'routine',
         missingViews: ['RMLO', 'RCC'], // ensure all views are present
         scheduling: {

--- a/app/lib/generate-seed-data.js
+++ b/app/lib/generate-seed-data.js
@@ -144,6 +144,7 @@ const generateClinicsForDay = (date, allParticipants, unit, usedParticipantsInSn
         slot,
         participant,
         clinic: firstClinic,
+        id: scenario?.participant?.config?.eventId,
         outcomeWeights: config.screening.outcomes[firstClinic.clinicType],
         forceStatus: scenario.participant.config.scheduling.status,
       })

--- a/app/lib/generators/clinic-generator.js
+++ b/app/lib/generators/clinic-generator.js
@@ -141,7 +141,7 @@ const determineSessionType = (sessionTimes) => {
   return startHour < 12 ? 'morning' : 'afternoon'
 }
 
-const generateClinic = (date, location, breastScreeningUnit, sessionTimes, overrides = null) => {
+const generateClinic = (date, location, breastScreeningUnit, sessionTimes, overrides = null, id = null) => {
   const clinicType = overrides?.clinicType || determineClinicType(location, breastScreeningUnit)
   const slots = generateTimeSlots(date, sessionTimes, clinicType)
 
@@ -163,7 +163,7 @@ const generateClinic = (date, location, breastScreeningUnit, sessionTimes, overr
   const totalSlots = slots.length * (isToday && clinicType !== 'assessment' ? 2 : 1)
 
   return {
-    id: generateId(),
+    id: id || generateId(),
     clinicCode: generateClinicCode(),
     date: clinicDate.format('YYYY-MM-DD'),
     breastScreeningUnitId: breastScreeningUnit.id,
@@ -197,6 +197,9 @@ const generateClinicsForBSU = ({ date, breastScreeningUnit }) => {
   // Check if this is today's generation
   const isToday = dayjs(date).startOf('day').isSame(dayjs().startOf('day'))
 
+  // Check if this is the first clinic of today - used to assign a specific ID
+  let isFirstClinicOfToday = isToday // Only track this for today
+
   // Generate clinics for each selected location
   return selectedLocations.flatMap((location, locationIndex) => {
     // Use location-specific patterns if available, otherwise use BSU patterns
@@ -207,26 +210,30 @@ const generateClinicsForBSU = ({ date, breastScreeningUnit }) => {
 
     if (selectedPattern.type === 'single') {
       // For single sessions, create one clinic
-      return [generateClinic(
+      const clinic = generateClinic(
         date,
         location,
         breastScreeningUnit,
         selectedPattern.sessions[0],
-        // Force first clinic of today to be screening
-        isToday && locationIndex === 0 ? { clinicType: 'screening' } : null
-)]
+        isToday && locationIndex === 0 ? { clinicType: 'screening' } : null,
+        isFirstClinicOfToday ? 'wtrl7jud' : null
+      )
+      isFirstClinicOfToday = false
+      return [clinic]
     } else {
       // For paired sessions, create two clinics
-      return selectedPattern.sessions.map((sessionTimes, sessionIndex) =>
-        generateClinic(
+      return selectedPattern.sessions.map((sessionTimes, sessionIndex) => {
+        const clinic = generateClinic(
           date,
           location,
           breastScreeningUnit,
-          sessionTimes,
-          // Force first clinic of today to be screening
-          isToday && locationIndex === 0 && sessionIndex === 0 ? { clinicType: 'screening' } : null
+          selectedPattern.sessions[0],
+          isToday && locationIndex === 0 ? { clinicType: 'screening' } : null,
+          isFirstClinicOfToday ? 'wtrl7jud' : null
         )
-      )
+        isFirstClinicOfToday = false
+        return clinic
+      })
     }
   })
 }

--- a/app/lib/generators/event-generator.js
+++ b/app/lib/generators/event-generator.js
@@ -59,7 +59,7 @@ const determineEventStatus = (slotDateTime, currentDateTime, attendanceWeights) 
   }
 }
 
-const generateEvent = ({ slot, participant, clinic, outcomeWeights, forceStatus = null }) => {
+const generateEvent = ({ slot, participant, clinic, outcomeWeights, forceStatus = null, id = null }) => {
   // Parse dates once
   const [hours, minutes] = config.clinics.simulatedTime.split(':')
   const simulatedDateTime = dayjs().hour(parseInt(hours)).minute(parseInt(minutes))
@@ -81,7 +81,7 @@ const generateEvent = ({ slot, participant, clinic, outcomeWeights, forceStatus 
   const eventStatus = forceStatus || determineEventStatus(slotDateTime, simulatedDateTime, attendanceWeights)
 
   const eventBase = {
-    id: generateId(),
+    id: id || generateId(),
     participantId: participant.id,
     clinicId: clinic.id,
     slotId: slot.id,


### PR DESCRIPTION
The seed data in the prototype is currently randomly generated each day. It's done like this so that most appointments / clinics are relative to today. Appointments in the past want to be complete, whilst those in the future want to be pending.

This causes an issue because the IDs are randomised - this means that a url for a specific appointment can't be used in a development ticket because it won't work in the future.

As a stepping stone towards making the urls more predictable this pr:
* Hardcodes the first clinic of 'today' to `wtrl7jud`
* Lets the test scenarios hardcode the event they get assigned to

This should mean that urls for the two test scenarios should be static going forward.

Janet Williams:
http://localhost:3000/clinics/wtrl7jud/events/5gpn41oi

Dianna McIntosh:
http://localhost:3000/clinics/wtrl7jud/events/0gdof6fh