### PR TITLE
Add links to common pages to index

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -21,4 +21,62 @@
   href: "/dashboard"
 }) }}
 
+<h2>Screening appointment</h2>
+{% set exampleParticipant = "/clinics/wtrl7jud/events/5gpn41oi" %}
+<ul>
+  <li>
+    <a href="{{ exampleParticipant }}">Initial appointment</a>
+  </li>
+  <li>
+    <a href="{{ exampleParticipant }}/attended-not-screened-reason">Appointment cannot go ahead</a>
+  </li>
+  <li>
+    <a href="{{ exampleParticipant }}/medical-information">Medical information</a>
+  </li>
+  <li>
+    <a href="{{ exampleParticipant }}/record-medical-information">Record medical information</a>
+    <ul>
+      <li>
+        <a href="{{ exampleParticipant }}/medical-information/symptoms/add?referrer={{ exampleParticipant }}/record-medical-information">Add a symptom</a>
+      </li>
+      <li>
+        <a href="{{ exampleParticipant }}/medical-information/hormone-replacement-therapy?referrer={{ exampleParticipant }}/record-medical-information">Hormone replacement therapy</a>
+      </li>
+      <li>
+        <a href="{{ exampleParticipant }}/medical-information/pregnancy-and-breastfeeding?referrer={{ exampleParticipant }}/record-medical-information">Pregnancy and breastfeeding</a>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <a href="{{ exampleParticipant }}/awaiting-images">Awaiting images</a>
+  </li>
+  <li>
+    <a href="{{ exampleParticipant }}/imaging">Imaging</a>
+  </li>
+  <li>
+    <a href="{{ exampleParticipant }}/confirm">Confirm</a>
+  </li>
+</ul>
+
+<h2>Other sections</h2>
+
+<ul>
+  <li>
+    <a href="/clinics">Clinics</a>
+    <ul>
+      <li><a href="/clinics/wtrl7jud">First clinic today</a></li>
+    </ul>
+  </li>
+
+  <li>
+    <a href="/reading">Image reading</a>
+  </li>
+  <li>
+    <a href="/participants">Participants</a>
+  </li>
+  <li>
+    <a href="/settings">Settings</a>
+  </li>
+</ul>
+
 {% endblock %}


### PR DESCRIPTION
## Description
Now that we have some predictable urls for screening appointments, we can have an index page that links to specific pages.

![Screenshot 2025-05-22 at 11 24 30](https://github.com/user-attachments/assets/ebf5e7d6-a355-42e3-9f3d-788ab66acbd7)
