### PR TITLE
Support saving participant data

### DIFF
--- a/app/lib/utils/event-data.js
+++ b/app/lib/utils/event-data.js
@@ -1,4 +1,5 @@
 // app/lib/utils/event-data.js
+const { getParticipant } = require('./participants.js')
 
 /**
  * Get an event by ID
@@ -17,7 +18,7 @@ const getEventData = (data, clinicId, eventId) => {
   const event = data.events.find(e => e.id === eventId && e.clinicId === clinicId)
   if (!event) return null
 
-  const participant = data.participants.find(p => p.id === event.participantId)
+  const participant = getParticipant(data, event.participantId)
   const unit = data.breastScreeningUnits.find(u => u.id === clinic.breastScreeningUnitId)
   const location = unit.locations.find(l => l.id === clinic.locationId)
 

--- a/app/routes/clinics.js
+++ b/app/routes/clinics.js
@@ -4,7 +4,7 @@ const dayjs = require('dayjs')
 const { getFilteredClinics, getClinicEvents } = require('../lib/utils/clinics')
 const { filterEventsByStatus } = require('../lib/utils/status')
 const { getReturnUrl, urlWithReferrer, appendReferrer } = require('../lib/utils/referrers')
-
+const { getParticipant } = require('../lib/utils/participants')
 
 /**
  * Get clinic and its related data from id
@@ -21,7 +21,7 @@ function getClinicData (data, clinicId) {
 
   // Get all participants for these events and add their details to the events
   const eventsWithParticipants = clinicEvents.map(event => {
-    const participant = data.participants.find(p => p.id === event.participantId)
+    const participant = getParticipant(data, event.participantId)
     return {
       ...event,
       participant,

--- a/app/routes/events.js
+++ b/app/routes/events.js
@@ -202,12 +202,11 @@ module.exports = router => {
 
       // Save changes and update status
       saveTempEventToEvent(data)
-      saveTempParticipantToParticipant
+      saveTempParticipantToParticipant(data)
       updateEventStatus(data, eventId, 'event_attended_not_screened')
 
       // Get participant info for message
-      const eventData = getEventData(data, clinicId, eventId)
-      const participantName = getFullName(eventData.participant)
+      const participantName = getFullName(data.participant)
       const participantEventUrl = `/clinics/${clinicId}/events/${eventId}`
 
       // Flash success message
@@ -563,11 +562,11 @@ module.exports = router => {
   router.post('/clinics/:clinicId/events/:eventId/attended-not-screened-answer', (req, res) => {
     const { clinicId, eventId } = req.params
 
-    const eventData = getEventData(req.session.data, clinicId, eventId)
-    const participantName = getFullName(eventData.participant)
+    const data = req.session.data
+
+    const participantName = getFullName(data.participant)
     const participantEventUrl = `/clinics/${clinicId}/events/${eventId}`
 
-    const data = req.session.data
     const notScreenedReason = data.event.appointmentStopped.stoppedReason
     const needsReschedule = data.event.appointmentStopped.needsReschedule
     const otherReasonDetails = data.event.appointmentStopped.otherDetails
@@ -616,8 +615,7 @@ module.exports = router => {
     const { clinicId, eventId } = req.params
 
     const data = req.session.data
-    const eventData = getEventData(req.session.data, clinicId, eventId)
-    const participantName = getFullName(eventData.participant)
+    const participantName = getFullName(data.participant)
     const participantEventUrl = `/clinics/${clinicId}/events/${eventId}`
 
     saveTempEventToEvent(data)

--- a/app/routes/participants.js
+++ b/app/routes/participants.js
@@ -1,6 +1,6 @@
 // app/routes/participants.js
 
-const { sortBySurname, getParticipantClinicHistory } = require('../lib/utils/participants')
+const { getParticipant, sortBySurname, getParticipantClinicHistory } = require('../lib/utils/participants')
 const { findById } = require('../lib/utils/arrays')
 
 module.exports = router => {
@@ -60,7 +60,7 @@ module.exports = router => {
   router.get('/participants/:participantId', (req, res) => {
     const data = req.session.data
     const participantId = req.params.participantId
-    const participant = findById(data.participants, participantId)
+    const participant = getParticipant(data, participantId)
 
     if (!participant) {
       res.redirect('/participants')

--- a/app/views/_includes/summary-lists/participant.njk
+++ b/app/views/_includes/summary-lists/participant.njk
@@ -255,7 +255,7 @@
           } if allowEdits
         ]
       }
-   } if not isMinimalParticipant,
+   },
    {
      key: {
        text: "Last known mammogram" if not hasAdditionalMammograms else "Last known mammograms"


### PR DESCRIPTION
This essentially duplicates the previous work on saving event data to do the equivalent for participant data.

eg, in a mammogram appointment we can save data to `participant[demographicInformation][firstName]` and that will then appear in the record. This is in a temp data store - it gets saved when going through a route that saves things - currently completing screening or going down the 'attended not screened' journeys.

One minor gotcha right now is you could go in and edit something on the record, then leave via back nav, and it wouldn't actually get saved. For now I'm not worrying about that.