### PR TITLE
Add ethnicity details

### DIFF
--- a/app/data/ethnicities.js
+++ b/app/data/ethnicities.js
@@ -4,32 +4,32 @@
 // https://design-system.service.gov.uk/patterns/equality-information/#asking-for-ethnic-group
 
 module.exports = {
-  "Asian or Asian British": [
-    "Indian",
-    "Pakistani",
-    "Bangladeshi",
-    "Chinese",
-    "Any other Asian background",
-  ],
-  "Black, African, Caribbean or Black British": [
-    "African",
-    "Caribbean",
-    "Any other Black, African or Caribbean background",
+  "White": [
+    "English, Welsh, Scottish, Northern Irish or British",
+    "Irish",
+    "Gypsy or Irish Traveller",
+    "Other White background",
   ],
   "Mixed or multiple ethnic groups": [
     "White and Black Caribbean",
     "White and Black African",
     "White and Asian",
-    "Any other mixed or multiple ethnic background",
+    "Other mixed or multiple ethnic background",
   ],
-  "White": [
-    "English, Welsh, Scottish, Northern Irish or British",
-    "Irish",
-    "Gypsy or Irish Traveller",
-    "Any other White background",
+  "Asian or Asian British": [
+    "Indian",
+    "Pakistani",
+    "Bangladeshi",
+    "Chinese",
+    "Other Asian or Asian British background",
+  ],
+  "Black, African, Caribbean or Black British": [
+    "African",
+    "Caribbean",
+    "Other Black, African, Caribbean or Black British background",
   ],
   "Other ethnic group": [
     "Arab",
-    "Any other ethnic group",
+    "Other ethnic background",
   ]
 }

--- a/app/lib/generators/participant-generator.js
+++ b/app/lib/generators/participant-generator.js
@@ -52,7 +52,7 @@ const generateEthnicity = (ethnicities) => {
   if (Math.random() < 0.2) {
     return {
       ethnicGroup,
-      ethnicBackground: 'Not provided'
+      ethnicBackground: 'Prefer not to say'
     }
   }
 

--- a/app/lib/utils/summary-list.js
+++ b/app/lib/utils/summary-list.js
@@ -23,18 +23,20 @@ const showMissingInformationLink = (summaryList) => {
   if (!summaryList?.rows) return summaryList
 
   const updatedRows = summaryList.rows.map(row => {
+
     const value = row.value?.text || row.value?.html
-    if (!isEmpty(value)) return row
+    const hasAction = row.actions && row.actions.items && row.actions.items.length > 0
+
+    // If value is not empty or there are no existing actions, return row as is
+    if (!isEmpty(value) || (!hasAction)) return row
 
     const keyText = row.actions?.items?.[0]?.visuallyHiddenText || row.key.text.toLowerCase()
     const href = row.actions?.items?.[0]?.href || '#'
 
-
     return {
       ...row,
       value: {
-        html: `<a href="${href}" class="nhsuk-link">Enter ${keyText}</a>`
-        // html: `<a href="${href}" class="nhsuk-link">Enter details</a>`
+        html: `<a href="${href}" class="nhsuk-link">Enter ${keyText} details</a>`
       },
       actions: {
         items: []

--- a/app/routes/events.js
+++ b/app/routes/events.js
@@ -471,6 +471,8 @@ module.exports = router => {
     'previous-mammograms/proceed-anyway',
     'medical-information/symptoms/type',
     'medical-information/symptoms/details',
+    'personal-details/ethnicity-details',
+
     // Completed screenings
     'images',
     'medical-information',

--- a/app/routes/events.js
+++ b/app/routes/events.js
@@ -121,10 +121,15 @@ module.exports = router => {
     })
   })
 
-  router.post('/clinics/:clinicId/events/:eventId/personal-details/ethnicity-details-answer', (req, res) => {
+  router.post('/clinics/:clinicId/events/:eventId/personal-details/ethnicity-answer', (req, res) => {
     const { clinicId, eventId } = req.params
     const data = req.session.data
     const selectedEthnicBackground = data.participant?.demographicInformation?.ethnicBackground
+
+    if (!selectedEthnicBackground) {
+      res.redirect(`/clinics/${clinicId}/events/${eventId}/personal-details/ethnicity`)
+      return
+    }
 
     // Map ethnic background to ethnic group
     if (selectedEthnicBackground && selectedEthnicBackground !== 'Prefer not to say') {
@@ -526,7 +531,7 @@ module.exports = router => {
     'previous-mammograms/proceed-anyway',
     'medical-information/symptoms/type',
     'medical-information/symptoms/details',
-    'personal-details/ethnicity-details',
+    'personal-details/ethnicity',
 
     // Completed screenings
     'images',

--- a/app/routes/events.js
+++ b/app/routes/events.js
@@ -121,6 +121,61 @@ module.exports = router => {
     })
   })
 
+  router.post('/clinics/:clinicId/events/:eventId/personal-details/ethnicity-details-answer', (req, res) => {
+    const { clinicId, eventId } = req.params
+    const data = req.session.data
+    const selectedEthnicBackground = data.participant?.demographicInformation?.ethnicBackground
+
+    // Map ethnic background to ethnic group
+    if (selectedEthnicBackground && selectedEthnicBackground !== 'Prefer not to say') {
+      const ethnicGroup = getEthnicGroupFromBackground(selectedEthnicBackground)
+      if (ethnicGroup) {
+        data.participant.demographicInformation.ethnicGroup = ethnicGroup
+      }
+
+      // Handle "Other" background details consolidation
+      cleanupOtherEthnicBackgroundDetails(data)
+    }
+    else if (selectedEthnicBackground === 'Prefer not to say') {
+      // Clear both fields if they prefer not to say
+      data.participant.demographicInformation.ethnicGroup = null
+      data.participant.demographicInformation.ethnicBackground = 'Prefer not to say'
+      data.participant.demographicInformation.otherEthnicBackgroundDetails = null
+    }
+
+    // Save the participant data back to the main array
+    saveTempParticipantToParticipant(data)
+
+    // Redirect back to the event page (or wherever appropriate)
+    res.redirect(`/clinics/${clinicId}/events/${eventId}`)
+  })
+
+  // Helper function to clean up otherEthnicBackgroundDetails from array to single value
+  function cleanupOtherEthnicBackgroundDetails(data) {
+    const otherDetails = data.participant?.demographicInformation?.otherEthnicBackgroundDetails
+
+    if (Array.isArray(otherDetails)) {
+      // Filter out empty strings and take the first non-empty value
+      const cleanedDetails = otherDetails.filter(detail => detail && detail.trim())
+      data.participant.demographicInformation.otherEthnicBackgroundDetails =
+        cleanedDetails.length > 0 ? cleanedDetails[0].trim() : null
+    }
+    // If it's already a string or null, leave it as is
+  }
+
+  // Helper function to map ethnic background to ethnic group
+  function getEthnicGroupFromBackground(ethnicBackground) {
+    const ethnicities = require('../data/ethnicities')
+
+    for (const [group, backgrounds] of Object.entries(ethnicities)) {
+      if (backgrounds.includes(ethnicBackground)) {
+        return group
+      }
+    }
+
+    return null // Return null if no match found
+  }
+
   // Handle screening completion
   // Todo - name this route better
   router.post('/clinics/:clinicId/events/:eventId/can-appointment-go-ahead-answer', (req, res) => {

--- a/app/views/_includes/cards/medical-information/other-information.njk
+++ b/app/views/_includes/cards/medical-information/other-information.njk
@@ -81,44 +81,44 @@
 {% endset %}
 
 {% set otherInformationHtml %}
-{{ summaryList({
-  rows: [
-    {
-      key: {
-        text: "Hormone replacement therapy (HRT)"
+  {{ summaryList({
+    rows: [
+      {
+        key: {
+          text: "Hormone replacement therapy (HRT)"
+        },
+        value: {
+          html: hrtHtml
+        },
+        actions: {
+          items: [
+            {
+              href: "./medical-information/hormone-replacement-therapy" | urlWithReferrer(currentUrl),
+              text: "Change",
+              visuallyHiddenText: "hormone replacement therapy (HRT)"
+            }
+          ]
+        }
       },
-      value: {
-        html: hrtHtml
-      },
-      actions: {
-        items: [
-          {
-            href: "./medical-information/hormone-replacement-therapy" | urlWithReferrer(currentUrl),
-            text: "Change",
-            visuallyHiddenText: "hormone replacement therapy (HRT)"
-          }
-        ]
+      {
+        key: {
+          text: "Pregnancy and breastfeeding"
+        },
+        value: {
+          html: pregnancyAndBreastfeedingHtml
+        },
+        actions: {
+          items: [
+            {
+              href: "./medical-information/pregnancy-and-breastfeeding" | urlWithReferrer(currentUrl),
+              text: "Change",
+              visuallyHiddenText: "pregnancy and breastfeeding"
+            }
+          ]
+        }
       }
-    },
-    {
-      key: {
-        text: "Pregnancy and breastfeeding"
-      },
-      value: {
-        html: pregnancyAndBreastfeedingHtml
-      },
-      actions: {
-        items: [
-          {
-            href: "./medical-information/pregnancy-and-breastfeeding" | urlWithReferrer(currentUrl),
-            text: "Change",
-            visuallyHiddenText: "pregnancy and breastfeeding"
-          }
-        ]
-      }
-    }
-  ]
-} | showMissingInformationLink) }}
+    ]
+  } | showMissingInformationLink ) }}
 {% endset %}
 
 {{ card({

--- a/app/views/_includes/summary-lists/participant.njk
+++ b/app/views/_includes/summary-lists/participant.njk
@@ -16,23 +16,40 @@
 
 {% set allowEdits = allowEdits | default(true) %}
 
-{% set ethnicGroup = participant.demographicInformation.ethnicGroup  %}
+{% set ethnicGroup = participant.demographicInformation.ethnicGroup %}
 {% set ethnicBackground = participant.demographicInformation.ethnicBackground %}
+
+{% set otherEthnicBackground = participant.demographicInformation.otherEthnicBackground %}
+
+{% if otherEthnicBackground and (ethnicBackground == "Other ethnic background") -%}
+  {% set ethnicBackground -%}
+    {{- ethnicBackground }} - {{ otherEthnicBackground }}
+  {%- endset %}
+{% endif %}
+
+{# {% set legendText = "Is " + (participant | getFullName) + " getting married soon?"%}
+
+{% set legendText %}Is {{ participant | getFullName }} getting married soon?{% endset %}
+
+ #}
+
+
+
+
+
 {% set ethnicityDetailsLink %}
-  <a href="#" class="nhsuk-link">Enter ethnicity details</a>
+  <a href="./{{ eventId }}/personal-details/ethnicity-details" class="nhsuk-link">Enter ethnicity details</a>
 {% endset %}
 
 {% set ethnicityHtml %}
-{% if ethnicGroup %}
-  {{ ethnicGroup }}
-  {% if ethnicBackground and ethnicBackground != 'Not provided' %}
-    ({{ethnicBackground | replace('Any other', 'any other')}})
+  {% if ethnicGroup or ethnicBackground %}
+    {{ ethnicGroup if ethnicGroup }}
+    {% if ethnicBackground and ethnicBackground != 'Prefer not to say' %}
+      ({{ ethnicBackground | replace('Other', 'other') }})
+    {% endif %}
+  {% else %}
+    {{ ethnicityDetailsLink | safe }}
   {% endif %}
-{% else %}
-  {{ ethnicityDetailsLink | safe }}
-{% endif %}
-
-
 {% endset %}
 
 {% set hasAdditionalMammograms = event.previousMammograms | length > 0 %}
@@ -198,10 +215,10 @@
      actions: {
         items: [
           {
-            href: "#",
+            href: eventId + "/personal-details/ethnicity-details",
             text: "Change",
-            visuallyHiddenText: "address"
-          } if false
+            visuallyHiddenText: "ethnicity"
+          }
         ]
       }
    },

--- a/app/views/_includes/summary-lists/participant.njk
+++ b/app/views/_includes/summary-lists/participant.njk
@@ -198,7 +198,7 @@
      actions: {
         items: [
           {
-            href: eventId + "/personal-details/ethnicity-details",
+            href: eventId + "/personal-details/ethnicity",
             text: "Change",
             visuallyHiddenText: "ethnicity"
           }

--- a/app/views/_includes/summary-lists/participant.njk
+++ b/app/views/_includes/summary-lists/participant.njk
@@ -18,37 +18,20 @@
 
 {% set ethnicGroup = participant.demographicInformation.ethnicGroup %}
 {% set ethnicBackground = participant.demographicInformation.ethnicBackground %}
+{% set otherEthnicBackgroundDetails = participant.demographicInformation.otherEthnicBackgroundDetails %}
 
-{% set otherEthnicBackground = participant.demographicInformation.otherEthnicBackground %}
-
-{% if otherEthnicBackground and (ethnicBackground == "Other ethnic background") -%}
+{% if otherEthnicBackgroundDetails and (ethnicBackground | lower | startsWith("other")) -%}
   {% set ethnicBackground -%}
-    {{- ethnicBackground }} - {{ otherEthnicBackground }}
+    {{- ethnicBackground }} - {{ otherEthnicBackgroundDetails }}
   {%- endset %}
 {% endif %}
 
-{# {% set legendText = "Is " + (participant | getFullName) + " getting married soon?"%}
-
-{% set legendText %}Is {{ participant | getFullName }} getting married soon?{% endset %}
-
- #}
-
-
-
-
-
-{% set ethnicityDetailsLink %}
-  <a href="./{{ eventId }}/personal-details/ethnicity-details" class="nhsuk-link">Enter ethnicity details</a>
-{% endset %}
-
 {% set ethnicityHtml %}
-  {% if ethnicGroup or ethnicBackground %}
-    {{ ethnicGroup if ethnicGroup }}
-    {% if ethnicBackground and ethnicBackground != 'Prefer not to say' %}
-      ({{ ethnicBackground | replace('Other', 'other') }})
-    {% endif %}
-  {% else %}
-    {{ ethnicityDetailsLink | safe }}
+  {{ ethnicGroup if ethnicGroup }}
+  {% if ethnicBackground and ethnicBackground != 'Prefer not to say' %}
+    ({{ ethnicBackground | replace('Other', 'other') }})
+    {% elseif ethnicBackground == "Prefer not to say" %}
+      {{ ethnicBackground }}
   {% endif %}
 {% endset %}
 
@@ -210,7 +193,7 @@
        text: "Ethnicity"
      },
      value: {
-       html: ethnicityHtml | safe
+       html: ethnicityHtml if ethnicGroup or ethnicBackground
      },
      actions: {
         items: [
@@ -309,4 +292,4 @@
       }
    } if false
   ]
-}) }}
+} | showMissingInformationLink) }}

--- a/app/views/events/mammography/personal-details/ethnicity-details.html
+++ b/app/views/events/mammography/personal-details/ethnicity-details.html
@@ -6,7 +6,8 @@
 
 {% set gridColumn = "nhsuk-grid-column-two-thirds" %}
 
-{% set formAction = "./../../" + eventId %}
+{% set formAction = "./ethnicity-details-answer" %}
+
 
 {# {% set back = {
   href: "/events/" + clinicId,
@@ -15,11 +16,9 @@
  #}
 
 
-
-
 {% block pageContent %}
 
-  {{ participant | log }}
+  {{ participant | log("participant") }}
 
   {% set unit = data.breastScreeningUnits | findById(clinic.breastScreeningUnitId) %}
 
@@ -32,130 +31,132 @@
 
   <p>Assure the participant that this information is collected to help the NHS identify trends that can help detect and prevent breast cancer. It will not be used to determine individual patient treatment or services.  </p>
 
-
-    {% set otherEthnicBackgroundHtml %}
+  {# This creates a unique input for each 'other' option, so that we don't end up with an array  #}
+  {% macro otherBackground(ethnicGroup) %}
     {{ input({
-      name: "participant[demographicInformation][otherEthnicBackground]",
-      id: "otherEthnicBackground",
-      value: participant.demographicInformation.otherEthnicBackground,
+      name: "participant[demographicInformation][otherEthnicBackgroundDetails]",
+      id: "other" + ethnicGroup + "EthnicBackgroundDetails",
+      value: participant.demographicInformation["otherEthnicBackgroundDetails"],
       label: {
-        text: "Provide details"
+        text: "How do they describe their background? (optional)"
       }
     } ) }}
+  {% endmacro %}
+
+  {% set ethnicityLegend %}
+    How does {{ participant | getFullName }} describe their ethnicity?
   {% endset %}
 
-
-
-{% set ethnicityQuestion %}
-  How does {{ participant | getFullName }} describe their ethnicity?
-{% endset %}
-
-
-  <h2>How does {{ participant | getFullName }} describe their ethnicity?</h2>
-
-{{ radios({
-  idPrefix: "white",
-  name: "participant[demographicInformation][ethnicBackground]",
-  value: participant.demographicInformation.ethnicBackground,
-  fieldset: {
+  {% call fieldset({
     legend: {
-      text: "White",
-      classes: "nhsuk-fieldset__legend--s"
+      text: ethnicityLegend,
+      classes: "nhsuk-fieldset__legend--m",
+      isPageHeading: false
     }
-  },
-  items: [
-    { value: "English, Welsh, Scottish, Northern Irish or British", text: "English, Welsh, Scottish, Northern Irish or British" },
-    { value: "Irish", text: "Irish" },
-    { value: "Gypsy or Irish Traveller", text: "Gypsy or Irish Traveller" },
-    { value: "Other White background", text: "Other White background" }
-  ]
-}) }}
+  }) %}
 
-{{ radios({
-  idPrefix: "mixed",
-  name: "participant[demographicInformation][ethnicBackground]",
-  value: participant.demographicInformation.ethnicBackground,
-  fieldset: {
-    legend: {
-      text: "Mixed or multiple ethnic groups",
-      classes: "nhsuk-fieldset__legend--s"
-    }
-  },
-  items: [
-    { value: "White and Black Caribbean", text: "White and Black Caribbean" },
-    { value: "White and Black African", text: "White and Black African" },
-    { value: "White and Asian", text: "White and Asian" },
-    { value: "Other mixed or multiple ethnic background", text: "Other mixed or multiple ethnic background" }
-  ]
-}) }}
+    {# White ethnic background #}
+    <h2 class="nhsuk-fieldset__legend--s">White</h2>
+    {{ radios({
+      idPrefix: "ethnicBackgroundWhite",
+      name: "participant[demographicInformation][ethnicBackground]",
+      value: participant.demographicInformation.ethnicBackground,
+      items: [
+        { value: "English, Welsh, Scottish, Northern Irish or British", text: "English, Welsh, Scottish, Northern Irish or British" },
+        { value: "Irish", text: "Irish" },
+        { value: "Gypsy or Irish Traveller", text: "Gypsy or Irish Traveller" },
+        { value: "Other White background",
+          text: "Other White background",
+          conditional: {
+            html: otherBackground("White")
+          }
+        }
+      ]
+    }) }}
 
-{{ radios({
-  idPrefix: "asian",
-  name: "participant[demographicInformation][ethnicBackground]",
-  value: participant.demographicInformation.ethnicBackground,
-  fieldset: {
-    legend: {
-      text: "Asian or Asian British",
-      classes: "nhsuk-fieldset__legend--s"
-    }
-  },
-  items: [
-    { value: "Indian", text: "Indian" },
-    { value: "Pakistani", text: "Pakistani" },
-    { value: "Bangladeshi", text: "Bangladeshi" },
-    { value: "Chinese", text: "Chinese" },
-    { value: "Other Asian or Asian British background", text: "Other Asian or Asian British background" }
-  ]
-}) }}
+    {# Mixed or multiple ethnic groups #}
+    <h2 class="nhsuk-fieldset__legend--s">Mixed or multiple ethnic groups</h2>
+    {{ radios({
+      idPrefix: "ethnicBackgroundMixed",
+      name: "participant[demographicInformation][ethnicBackground]",
+      value: participant.demographicInformation.ethnicBackground,
+      items: [
+        { value: "White and Black Caribbean", text: "White and Black Caribbean" },
+        { value: "White and Black African", text: "White and Black African" },
+        { value: "White and Asian", text: "White and Asian" },
+        { value: "Other mixed or multiple ethnic background",
+          text: "Other mixed or multiple ethnic background",
+          conditional: {
+            html: otherBackground("Mixed")
+          }
+        }
+      ]
+    }) }}
 
-{{ radios({
-  idPrefix: "black",
-  name: "participant[demographicInformation][ethnicBackground]",
-  value: participant.demographicInformation.ethnicBackground,
-  fieldset: {
-    legend: {
-      text: "Black, African, Caribbean or Black British",
-      classes: "nhsuk-fieldset__legend--s"
-    }
-  },
-  items: [
-    { value: "African", text: "African" },
-    { value: "Caribbean", text: "Caribbean" },
-    { value: "Other Black, African, Caribbean or Black British background", text: "Other Black, African, Caribbean or Black British background" }
-  ]
-}) }}
+    {# Asian or Asian British #}
+    <h2 class="nhsuk-fieldset__legend--s">Asian or Asian British</h2>
+    {{ radios({
+      idPrefix: "ethnicBackgroundAsian",
+      name: "participant[demographicInformation][ethnicBackground]",
+      value: participant.demographicInformation.ethnicBackground,
+      items: [
+        { value: "Indian", text: "Indian" },
+        { value: "Pakistani", text: "Pakistani" },
+        { value: "Bangladeshi", text: "Bangladeshi" },
+        { value: "Chinese", text: "Chinese" },
+        { value: "Other Asian or Asian British background",
+          text: "Other Asian or Asian British background",
+          conditional: {
+            html: otherBackground("Asian")
+          }
+        }
+      ]
+    }) }}
 
-{{ radios({
-  idPrefix: "other",
-  name: "participant[demographicInformation][ethnicBackground]",
-  value: participant.demographicInformation.ethnicBackground,
-  fieldset: {
-    legend: {
-      text: "Other",
-      classes: "nhsuk-fieldset__legend--s"
-    }
-  },
-  items: [
-    { value: "Arab", text: "Arab" },
-    {
-      value: "Other ethnic background",
-      text: "Other ethnic background",
-      conditional: {
-        html: otherEthnicBackgroundHtml
-      }
-    },
-    {
-      divider: "or"
-    },
-    {
-      value: "Prefer not to say",
-      text: "Prefer not to say"
-    }
-  ]
-}) }}
+    {# Black, African, Caribbean or Black British #}
+    <h2 class="nhsuk-fieldset__legend--s">Black, African, Caribbean or Black British</h2>
+    {{ radios({
+      idPrefix: "ethnicBackgroundBlack",
+      name: "participant[demographicInformation][ethnicBackground]",
+      value: participant.demographicInformation.ethnicBackground,
+      items: [
+        { value: "African", text: "African" },
+        { value: "Caribbean", text: "Caribbean" },
+        { value: "Other Black, African, Caribbean or Black British background",
+          text: "Other Black, African, Caribbean or Black British background",
+          conditional: {
+            html: otherBackground("Black")
+          }
+        }
+      ]
+    }) }}
 
+    {# Other ethnic group #}
+    <h2 class="nhsuk-fieldset__legend--s">Other ethnic group</h2>
+    {{ radios({
+      idPrefix: "ethnicBackgroundOther",
+      name: "participant[demographicInformation][ethnicBackground]",
+      value: participant.demographicInformation.ethnicBackground,
+      items: [
+        { value: "Arab", text: "Arab" },
+        {
+          value: "Other ethnic background",
+          text: "Other ethnic background",
+          conditional: {
+            html: otherBackground("Other")
+          }
+        },
+        {
+          divider: "or"
+        },
+        {
+          value: "Prefer not to say",
+          text: "Prefer not to say"
+        }
+      ]
+    }) }}
 
-
+  {% endcall %}
 
   {{ button({
     text: "Save"

--- a/app/views/events/mammography/personal-details/ethnicity-details.html
+++ b/app/views/events/mammography/personal-details/ethnicity-details.html
@@ -6,7 +6,7 @@
 
 {% set gridColumn = "nhsuk-grid-column-two-thirds" %}
 
-{% set formAction = "./../personal-details" | getReturnUrl(referrerChain)  %}
+{% set formAction = "./../../" + eventId %}
 
 {# {% set back = {
   href: "/events/" + clinicId,
@@ -33,8 +33,11 @@
   <p>Assure the participant that this information is collected to help the NHS identify trends that can help detect and prevent breast cancer. It will not be used to determine individual patient treatment or services.  </p>
 
 
-    {% set otherEthnicGroup %}
+    {% set otherEthnicBackgroundHtml %}
     {{ input({
+      name: "participant[demographicInformation][otherEthnicBackground]",
+      id: "otherEthnicBackground",
+      value: participant.demographicInformation.otherEthnicBackground,
       label: {
         text: "Provide details"
       }
@@ -52,8 +55,8 @@
 
 {{ radios({
   idPrefix: "white",
-  name: "participant[personalDetails][ethnicity]",
-  value: participant.personalDetails.ethnicity,
+  name: "participant[demographicInformation][ethnicBackground]",
+  value: participant.demographicInformation.ethnicBackground,
   fieldset: {
     legend: {
       text: "White",
@@ -61,17 +64,17 @@
     }
   },
   items: [
-    { value: "whiteBritish", text: "English, Welsh, Scottish, Northern Irish or British" },
-    { value: "whiteIrish", text: "Irish" },
-    { value: "gypsyOrIrishTraveller", text: "Gypsy or Irish Traveller" },
-    { value: "otherWhiteBackground", text: "Other White background" }
+    { value: "English, Welsh, Scottish, Northern Irish or British", text: "English, Welsh, Scottish, Northern Irish or British" },
+    { value: "Irish", text: "Irish" },
+    { value: "Gypsy or Irish Traveller", text: "Gypsy or Irish Traveller" },
+    { value: "Other White background", text: "Other White background" }
   ]
 }) }}
 
 {{ radios({
   idPrefix: "mixed",
-  name: "participant[personalDetails][ethnicity]",
-  value: participant.personalDetails.ethnicity,
+  name: "participant[demographicInformation][ethnicBackground]",
+  value: participant.demographicInformation.ethnicBackground,
   fieldset: {
     legend: {
       text: "Mixed or multiple ethnic groups",
@@ -79,17 +82,17 @@
     }
   },
   items: [
-    { value: "whiteAndBlackCaribbean", text: "White and Black Caribbean" },
-    { value: "whiteAndBlackAfrican", text: "White and Black African" },
-    { value: "whiteAndAsian", text: "White and Asian" },
-    { value: "otherMixedBackground", text: "Other mixed or multiple ethnic background" }
+    { value: "White and Black Caribbean", text: "White and Black Caribbean" },
+    { value: "White and Black African", text: "White and Black African" },
+    { value: "White and Asian", text: "White and Asian" },
+    { value: "Other mixed or multiple ethnic background", text: "Other mixed or multiple ethnic background" }
   ]
 }) }}
 
 {{ radios({
   idPrefix: "asian",
-  name: "participant[personalDetails][ethnicity]",
-  value: participant.personalDetails.ethnicity,
+  name: "participant[demographicInformation][ethnicBackground]",
+  value: participant.demographicInformation.ethnicBackground,
   fieldset: {
     legend: {
       text: "Asian or Asian British",
@@ -97,18 +100,18 @@
     }
   },
   items: [
-    { value: "indian", text: "Indian" },
-    { value: "pakistani", text: "Pakistani" },
-    { value: "bangladeshi", text: "Bangladeshi" },
-    { value: "chinese", text: "Chinese" },
-    { value: "otherAsianOrAsianBritishBackground", text: "Other Asian or Asian British background" }
+    { value: "Indian", text: "Indian" },
+    { value: "Pakistani", text: "Pakistani" },
+    { value: "Bangladeshi", text: "Bangladeshi" },
+    { value: "Chinese", text: "Chinese" },
+    { value: "Other Asian or Asian British background", text: "Other Asian or Asian British background" }
   ]
 }) }}
 
 {{ radios({
   idPrefix: "black",
-  name: "participant[personalDetails][ethnicity]",
-  value: participant.personalDetails.ethnicity,
+  name: "participant[demographicInformation][ethnicBackground]",
+  value: participant.demographicInformation.ethnicBackground,
   fieldset: {
     legend: {
       text: "Black, African, Caribbean or Black British",
@@ -116,16 +119,16 @@
     }
   },
   items: [
-    { value: "african", text: "African" },
-    { value: "caribbean", text: "Caribbean" },
-    { value: "otherBlackAfricanCaribbeanBackground", text: "Other Black, African, Caribbean or Black British background" }
+    { value: "African", text: "African" },
+    { value: "Caribbean", text: "Caribbean" },
+    { value: "Other Black, African, Caribbean or Black British background", text: "Other Black, African, Caribbean or Black British background" }
   ]
 }) }}
 
 {{ radios({
   idPrefix: "other",
-  name: "participant[personalDetails][ethnicity]",
-  value: participant.personalDetails.ethnicity,
+  name: "participant[demographicInformation][ethnicBackground]",
+  value: participant.demographicInformation.ethnicBackground,
   fieldset: {
     legend: {
       text: "Other",
@@ -133,18 +136,19 @@
     }
   },
   items: [
+    { value: "Arab", text: "Arab" },
     {
-      value: "otherEthnicGroup",
-      text: "Other ethnic group",
+      value: "Other ethnic background",
+      text: "Other ethnic background",
       conditional: {
-        html: otherEthnicGroup
+        html: otherEthnicBackgroundHtml
       }
     },
     {
       divider: "or"
     },
     {
-      value: "preferNotToSay",
+      value: "Prefer not to say",
       text: "Prefer not to say"
     }
   ]

--- a/app/views/events/mammography/personal-details/ethnicity-details.html
+++ b/app/views/events/mammography/personal-details/ethnicity-details.html
@@ -1,0 +1,162 @@
+
+{% extends 'layout-app.html' %}
+
+
+{% set pageHeading = "Participant ethnicity" %}
+
+{% set gridColumn = "nhsuk-grid-column-two-thirds" %}
+
+{% set formAction = "./../personal-details" | getReturnUrl(referrerChain)  %}
+
+{# {% set back = {
+  href: "/events/" + clinicId,
+  text: "Back"
+} %}
+ #}
+
+
+
+
+{% block pageContent %}
+
+  {{ participant | log }}
+
+  {% set unit = data.breastScreeningUnits | findById(clinic.breastScreeningUnitId) %}
+
+  <h1 class="nhsuk-heading-l">
+    <span class="nhsuk-caption-m">
+      {{ participant | getFullName }}
+    </span>
+    {{ pageHeading }}
+  </h1>
+
+  <p>Assure the participant that this information is collected to help the NHS identify trends that can help detect and prevent breast cancer. It will not be used to determine individual patient treatment or services.  </p>
+
+
+    {% set otherEthnicGroup %}
+    {{ input({
+      label: {
+        text: "Provide details"
+      }
+    } ) }}
+  {% endset %}
+
+
+
+{% set ethnicityQuestion %}
+  How does {{ participant | getFullName }} describe their ethnicity?
+{% endset %}
+
+
+  <h2>How does {{ participant | getFullName }} describe their ethnicity?</h2>
+
+{{ radios({
+  idPrefix: "white",
+  name: "participant[personalDetails][ethnicity]",
+  value: participant.personalDetails.ethnicity,
+  fieldset: {
+    legend: {
+      text: "White",
+      classes: "nhsuk-fieldset__legend--s"
+    }
+  },
+  items: [
+    { value: "whiteBritish", text: "English, Welsh, Scottish, Northern Irish or British" },
+    { value: "whiteIrish", text: "Irish" },
+    { value: "gypsyOrIrishTraveller", text: "Gypsy or Irish Traveller" },
+    { value: "otherWhiteBackground", text: "Other White background" }
+  ]
+}) }}
+
+{{ radios({
+  idPrefix: "mixed",
+  name: "participant[personalDetails][ethnicity]",
+  value: participant.personalDetails.ethnicity,
+  fieldset: {
+    legend: {
+      text: "Mixed or multiple ethnic groups",
+      classes: "nhsuk-fieldset__legend--s"
+    }
+  },
+  items: [
+    { value: "whiteAndBlackCaribbean", text: "White and Black Caribbean" },
+    { value: "whiteAndBlackAfrican", text: "White and Black African" },
+    { value: "whiteAndAsian", text: "White and Asian" },
+    { value: "otherMixedBackground", text: "Other mixed or multiple ethnic background" }
+  ]
+}) }}
+
+{{ radios({
+  idPrefix: "asian",
+  name: "participant[personalDetails][ethnicity]",
+  value: participant.personalDetails.ethnicity,
+  fieldset: {
+    legend: {
+      text: "Asian or Asian British",
+      classes: "nhsuk-fieldset__legend--s"
+    }
+  },
+  items: [
+    { value: "indian", text: "Indian" },
+    { value: "pakistani", text: "Pakistani" },
+    { value: "bangladeshi", text: "Bangladeshi" },
+    { value: "chinese", text: "Chinese" },
+    { value: "otherAsianOrAsianBritishBackground", text: "Other Asian or Asian British background" }
+  ]
+}) }}
+
+{{ radios({
+  idPrefix: "black",
+  name: "participant[personalDetails][ethnicity]",
+  value: participant.personalDetails.ethnicity,
+  fieldset: {
+    legend: {
+      text: "Black, African, Caribbean or Black British",
+      classes: "nhsuk-fieldset__legend--s"
+    }
+  },
+  items: [
+    { value: "african", text: "African" },
+    { value: "caribbean", text: "Caribbean" },
+    { value: "otherBlackAfricanCaribbeanBackground", text: "Other Black, African, Caribbean or Black British background" }
+  ]
+}) }}
+
+{{ radios({
+  idPrefix: "other",
+  name: "participant[personalDetails][ethnicity]",
+  value: participant.personalDetails.ethnicity,
+  fieldset: {
+    legend: {
+      text: "Other",
+      classes: "nhsuk-fieldset__legend--s"
+    }
+  },
+  items: [
+    {
+      value: "otherEthnicGroup",
+      text: "Other ethnic group",
+      conditional: {
+        html: otherEthnicGroup
+      }
+    },
+    {
+      divider: "or"
+    },
+    {
+      value: "preferNotToSay",
+      text: "Prefer not to say"
+    }
+  ]
+}) }}
+
+
+
+
+  {{ button({
+    text: "Save"
+  }) }}
+
+
+{% endblock %}
+

--- a/app/views/events/mammography/personal-details/ethnicity.html
+++ b/app/views/events/mammography/personal-details/ethnicity.html
@@ -6,7 +6,7 @@
 
 {% set gridColumn = "nhsuk-grid-column-two-thirds" %}
 
-{% set formAction = "./ethnicity-details-answer" %}
+{% set formAction = "./ethnicity-answer" %}
 
 
 {# {% set back = {

--- a/app/views/events/mammography/personal-details/ethnicity.html
+++ b/app/views/events/mammography/personal-details/ethnicity.html
@@ -2,7 +2,7 @@
 {% extends 'layout-app.html' %}
 
 
-{% set pageHeading = "Participant ethnicity" %}
+{% set pageHeading = "Ethnicity" %}
 
 {% set gridColumn = "nhsuk-grid-column-two-thirds" %}
 
@@ -29,7 +29,7 @@
     {{ pageHeading }}
   </h1>
 
-  <p>Assure the participant that this information is collected to help the NHS identify trends that can help detect and prevent breast cancer. It will not be used to determine individual patient treatment or services.  </p>
+  <p>Assure the participant that this information is collected to help the NHS identify breast cancer trends so screening programmes can be improved. It will not be used to determine individual patient treatment or services.</p>
 
   {# This creates a unique input for each 'other' option, so that we don't end up with an array  #}
   {% macro otherBackground(ethnicGroup) %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -15,7 +15,6 @@
   Index page to link to bits of the prototype.
 </p>
 
-
 {{ button({
   text: "Dashboard",
   href: "/dashboard"
@@ -26,6 +25,9 @@
 <ul>
   <li>
     <a href="{{ exampleParticipant }}">Initial appointment</a>
+  </li>
+  <li>
+    <a href="{{ exampleParticipant }}/personal-details/ethnicity-details">Ethnicity</a>
   </li>
   <li>
     <a href="{{ exampleParticipant }}/previous-mammograms/add">Add details of a previous mammogram</a>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -27,7 +27,7 @@
     <a href="{{ exampleParticipant }}">Initial appointment</a>
   </li>
   <li>
-    <a href="{{ exampleParticipant }}/personal-details/ethnicity-details">Ethnicity</a>
+    <a href="{{ exampleParticipant }}/personal-details/ethnicity">Ethnicity</a>
   </li>
   <li>
     <a href="{{ exampleParticipant }}/previous-mammograms/add">Add details of a previous mammogram</a>


### PR DESCRIPTION
Adds an ethnicity edit page.

This tries to capture similar data to the GOV.UK ethnicity pattern, but presented as a flat list for mammographers.

When an ethnic background is picked, in the background the ethnic group is derived. This also means if we later have a pre-appointment questionnaire as a two part question (ethnic group and ethnic background), then that can be displayed and edited with this form.

![localhost_3000_clinics_wtrl7jud_events_5gpn41oi_personal-details_ethnicity 2](https://github.com/user-attachments/assets/2275267a-bf6a-4535-bb25-ca33071d49f7)
