### PR TITLE
Minor content changes to pregnancy and symptoms pages

### DIFF
--- a/app/views/events/mammography/medical-information/pregnancy-and-breastfeeding.html
+++ b/app/views/events/mammography/medical-information/pregnancy-and-breastfeeding.html
@@ -63,7 +63,7 @@
       name: "event[medicalInformation][pregnancyAndBreastfeeding][currentlyBreastfeedingDuration]",
       value: event.medicalInformation.pregnancyAndBreastfeeding.currentlyBreastfeedingDuration,
       label: {
-        text: "For how long"
+        text: "For how long?"
       },
       classes: "nhsuk-u-width-two-thirds",
       hint: {
@@ -91,7 +91,7 @@
     value: event.medicalInformation.pregnancyAndBreastfeeding.pregnancyStatus,
     fieldset: {
       legend: {
-        text: 'Is the participant pregnant?',
+        text: "Is " + (participant | getFullName) + " pregnant?",
         classes: "nhsuk-fieldset__legend--m",
         isPageHeading: false
       }
@@ -129,7 +129,7 @@
     value: event.medicalInformation.pregnancyAndBreastfeeding.breastfeedingStatus,
      fieldset: {
       legend: {
-        text: 'Is the participant currently breastfeeding?',
+        text: "Is " + (participant | getFullName) + " currently breastfeeding?",
         classes: "nhsuk-fieldset__legend--m",
         isPageHeading: false
       }
@@ -144,7 +144,7 @@
     },
     {
       value: "recentlyStopped",
-      text: "No, but recently stopped",
+      text: "No, but stopped recently",
       conditional: {
         html: recentlyBreastfeeding
       }

--- a/app/views/events/mammography/medical-information/symptoms/details.html
+++ b/app/views/events/mammography/medical-information/symptoms/details.html
@@ -482,7 +482,7 @@
       items: [
         {
           value: "yes",
-          text: "The symptom has recently stopped",
+          text: "The symptom has recently resolved",
           conditional: {
             html: stymptomStoppedHtml
           }


### PR DESCRIPTION
## Text updates

- Revised text on symptoms page ('resolved' not 'stopped') based on clinical feedback
- Added dynamic personalisation to pregnancy questions
