### PR TITLE
Add moj button menu and apply to adding a symptom

### DIFF
--- a/app/assets/javascript/button-menu.js
+++ b/app/assets/javascript/button-menu.js
@@ -1,0 +1,254 @@
+// Button Menu Component - adapted from MOJ Frontend
+// https://github.com/ministryofjustice/moj-frontend/blob/main/src/moj/components/button-menu/button-menu.mjs
+// Provides a dropdown menu for multiple button actions
+
+class ButtonMenu {
+  constructor(element, config = {}) {
+    this.element = element
+    this.config = {
+      buttonText: 'Actions',
+      alignMenu: 'left',
+      buttonClasses: '',
+      ...this.parseDataAttributes(),
+      ...config,
+    }
+
+    // If only one button is provided, don't initiate a menu and toggle button
+    // if classes have been provided for the toggleButton, apply them to the single item
+    if (this.element.children.length === 1) {
+      const button = this.element.children[0]
+
+      button.classList.forEach((className) => {
+        if (className.startsWith('nhsuk-button-')) {
+          button.classList.remove(className)
+        }
+
+        button.classList.remove('app-button-menu__item')
+        button.classList.add('app-button-menu__single-button')
+      })
+
+      if (this.config.buttonClasses) {
+        button.classList.add(...this.config.buttonClasses.split(' '))
+      }
+    }
+    // Otherwise initialise a button menu
+    if (this.element.children.length > 1) {
+      this.initMenu()
+    }
+  }
+
+  // Parse configuration from data attributes
+  parseDataAttributes() {
+    const dataset = this.element.dataset
+    const config = {}
+
+    if (dataset.buttonText) config.buttonText = dataset.buttonText
+    if (dataset.alignMenu) config.alignMenu = dataset.alignMenu
+    if (dataset.buttonClasses) config.buttonClasses = dataset.buttonClasses
+
+    return config
+  }
+
+  initMenu() {
+    this.menu = this.createMenu()
+    this.element.insertAdjacentHTML('afterbegin', this.toggleTemplate())
+    this.setupMenuItems()
+
+    this.menuToggle = this.element.querySelector(':scope > button')
+    this.items = this.menu.querySelectorAll('a, button')
+
+    this.menuToggle.addEventListener('click', (event) => {
+      this.toggleMenu(event)
+    })
+
+    this.element.addEventListener('keydown', (event) => {
+      this.handleKeyDown(event)
+    })
+
+    document.addEventListener('click', (event) => {
+      if (event.target instanceof Node && !this.element.contains(event.target)) {
+        this.closeMenu(false)
+      }
+    })
+  }
+
+  createMenu() {
+    const menu = document.createElement('ul')
+
+    menu.setAttribute('role', 'list')
+    menu.hidden = true
+    menu.classList.add('app-button-menu__wrapper')
+
+    if (this.config.alignMenu === 'right') {
+      menu.classList.add('app-button-menu__wrapper--right')
+    }
+
+    this.element.appendChild(menu)
+
+    while (this.element.firstChild !== menu) {
+      menu.appendChild(this.element.firstChild)
+    }
+
+    return menu
+  }
+
+  setupMenuItems() {
+    Array.from(this.menu.children).forEach((menuItem) => {
+      // wrap item in li tag
+      const listItem = document.createElement('li')
+      this.menu.insertBefore(listItem, menuItem)
+      listItem.appendChild(menuItem)
+
+      menuItem.setAttribute('tabindex', '-1')
+
+      if (menuItem.tagName === 'BUTTON') {
+        menuItem.setAttribute('type', 'button')
+      }
+
+      menuItem.classList.forEach((className) => {
+        if (className.startsWith('nhsuk-button')) {
+          menuItem.classList.remove(className)
+        }
+      })
+
+      // add a slight delay after click before closing the menu, makes it *feel* better
+      menuItem.addEventListener('click', () => {
+        setTimeout(() => {
+          this.closeMenu(false)
+        }, 50)
+      })
+    })
+  }
+
+  toggleTemplate() {
+    return `
+    <button type="button" class="nhsuk-button app-button-menu__toggle-button ${this.config.buttonClasses || ''}" aria-haspopup="true" aria-expanded="false">
+      <span>
+       ${this.config.buttonText}
+       <svg width="11" height="5" viewBox="0 0 11 5"  xmlns="http://www.w3.org/2000/svg">
+         <path d="M5.5 0L11 5L0 5L5.5 0Z" fill="currentColor"/>
+       </svg>
+      </span>
+    </button>`
+  }
+
+  isOpen() {
+    return this.menuToggle.getAttribute('aria-expanded') === 'true'
+  }
+
+  toggleMenu(event) {
+    event.preventDefault()
+
+    // If menu is triggered with mouse don't move focus to first item
+    const keyboardEvent = event.detail === 0
+    const focusIndex = keyboardEvent ? 0 : -1
+
+    if (this.isOpen()) {
+      this.closeMenu()
+    } else {
+      this.openMenu(focusIndex)
+    }
+  }
+
+  // Opens the menu and optionally sets the focus to the item with given index
+  openMenu(focusIndex = 0) {
+    this.menu.hidden = false
+    this.menuToggle.setAttribute('aria-expanded', 'true')
+    if (focusIndex !== -1) {
+      this.focusItem(focusIndex)
+    }
+  }
+
+  // Closes the menu and optionally returns focus back to menuToggle
+  closeMenu(moveFocus = true) {
+    this.menu.hidden = true
+    this.menuToggle.setAttribute('aria-expanded', 'false')
+    if (moveFocus) {
+      this.menuToggle.focus()
+    }
+  }
+
+  // Focuses the menu item at the specified index
+  focusItem(index) {
+    if (index >= this.items.length) index = 0
+    if (index < 0) index = this.items.length - 1
+
+    const menuItem = this.items.item(index)
+    if (menuItem) {
+      menuItem.focus()
+    }
+  }
+
+  currentFocusIndex() {
+    const activeElement = document.activeElement
+    const menuItems = Array.from(this.items)
+
+    return (
+      (activeElement instanceof HTMLAnchorElement ||
+        activeElement instanceof HTMLButtonElement) &&
+      menuItems.indexOf(activeElement)
+    )
+  }
+
+  handleKeyDown(event) {
+    if (event.target === this.menuToggle) {
+      switch (event.key) {
+        case 'ArrowDown':
+          event.preventDefault()
+          this.openMenu()
+          break
+        case 'ArrowUp':
+          event.preventDefault()
+          this.openMenu(this.items.length - 1)
+          break
+      }
+    }
+
+    if (
+      event.target instanceof Node &&
+      this.menu.contains(event.target) &&
+      this.isOpen()
+    ) {
+      switch (event.key) {
+        case 'ArrowDown':
+          event.preventDefault()
+          if (this.currentFocusIndex() !== -1) {
+            this.focusItem(this.currentFocusIndex() + 1)
+          }
+          break
+        case 'ArrowUp':
+          event.preventDefault()
+          if (this.currentFocusIndex() !== -1) {
+            this.focusItem(this.currentFocusIndex() - 1)
+          }
+          break
+        case 'Home':
+          event.preventDefault()
+          this.focusItem(0)
+          break
+        case 'End':
+          event.preventDefault()
+          this.focusItem(this.items.length - 1)
+          break
+      }
+    }
+
+    if (event.key === 'Escape' && this.isOpen()) {
+      this.closeMenu()
+    }
+    if (event.key === 'Tab' && this.isOpen()) {
+      this.closeMenu(false)
+    }
+  }
+}
+
+// Initialize all button menus when DOM is ready
+document.addEventListener('DOMContentLoaded', () => {
+  const buttonMenus = document.querySelectorAll('[data-module="app-button-menu"]')
+  buttonMenus.forEach(element => {
+    new ButtonMenu(element)
+  })
+})
+
+// Export for manual initialization if needed
+window.ButtonMenu = ButtonMenu

--- a/app/assets/sass/components/_button-menu.scss
+++ b/app/assets/sass/components/_button-menu.scss
@@ -33,17 +33,19 @@
 
 .app-button-menu__wrapper {
   z-index: 10;
+  @include nhsuk-print-hide;
   margin: 5px 0 0; // 2px shadow, 3px gap
   padding: 0;
   list-style: none;
   background-color: $color_nhsuk-white;
   border: 1px solid $nhsuk-border-color;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  border-bottom: nhsuk-spacing(1) solid $color_nhsuk-grey-4;
+  // box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 
   &,
   .app-button-group--inline {
     position: absolute;
-    width: 200px;
+    width: 300px;
   }
 
   &--right {
@@ -78,13 +80,15 @@
   margin-right: 0;
   margin-bottom: 0;
   margin-left: 0;
-  padding: nhsuk-spacing(2);
-  border: $nhsuk-border-width-form-element solid transparent;
+  padding: nhsuk-spacing(3);
+  // border: $nhsuk-border-width-form-element solid transparent;
   // border-bottom: 1px solid $nhsuk-secondary-border-color;
-  border-bottom: 1px solid $nhsuk-form-border-color;
+  // border-bottom: 1px solid $nhsuk-form-border-color;
+  border-top: 1px solid $color_nhsuk-grey-3;
   border-radius: 0;
-  color: $nhsuk-text-color;
-  background-color: $color_nhsuk-grey-5;
+  // color: $nhsuk-text-color;
+  color: $color_nhsuk-blue;
+  background-color: $color_nhsuk-white;
   text-align: left;
   vertical-align: top;
   cursor: pointer;
@@ -96,13 +100,13 @@
   &:visited,
   &:active,
   &:hover {
-    color: $nhsuk-text-color;
-    text-decoration: none;
+    // color: $nhsuk-text-color;
+    // text-decoration: none;
   }
 
   &:active,
   &:hover {
-    color: $color_nhsuk-white;
+    // color: $color_nhsuk-white;
   }
 
   // Fix unwanted button padding in Firefox
@@ -112,20 +116,21 @@
   }
 
   &:hover {
-    background-color: $color_nhsuk-blue;
+    background-color: $color_nhsuk-grey-5;
   }
 
   &:focus {
     z-index: 10;
     border-color: $nhsuk-focus-color;
     outline: $nhsuk-focus-width solid transparent;
-    box-shadow: inset 0 0 0 1px $nhsuk-focus-color;
+    box-shadow: inset 0 0 0 4px $nhsuk-focus-color;
   }
 
   &:focus:not(:active):not(:hover) {
     border-color: $nhsuk-focus-color;
     color: $nhsuk-focus-text-color;
     background-color: $nhsuk-focus-color;
-    box-shadow: 0 2px 0 $nhsuk-focus-text-color;
+    // box-shadow: inset 0 -8px 0 $nhsuk-focus-text-color;
+    box-shadow: inset 0 ($nhsuk-focus-width * -1) $nhsuk-focus-text-color;
   }
 }

--- a/app/assets/sass/components/_button-menu.scss
+++ b/app/assets/sass/components/_button-menu.scss
@@ -1,0 +1,131 @@
+// Button Menu Component
+// Adapted from MOJ Frontend for NHS prototype use
+@use 'nhsuk-frontend/packages/core/settings' as *;
+@use 'nhsuk-frontend/packages/core/tools' as *;
+@use 'nhsuk-frontend/packages/core/objects' as *;
+@use 'nhsuk-frontend/packages/core/styles/typography' as *;
+
+.app-button-menu {
+  display: inline-block;
+  position: relative;
+}
+
+.app-button-menu__toggle-button,
+.app-button-menu__single-button {
+  margin-bottom: 0;
+  vertical-align: baseline;
+}
+
+.app-button-menu__toggle-button span {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.app-button-menu__toggle-button svg {
+  margin-top: 2px;
+  transform: rotate(180deg);
+}
+
+.app-button-menu__toggle-button[aria-expanded="true"] svg {
+  transform: rotate(0deg);
+}
+
+.app-button-menu__wrapper {
+  z-index: 10;
+  margin: 5px 0 0; // 2px shadow, 3px gap
+  padding: 0;
+  list-style: none;
+  background-color: $color_nhsuk-white;
+  border: 1px solid $nhsuk-border-color;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+
+  &,
+  .app-button-group--inline {
+    position: absolute;
+    width: 200px;
+  }
+
+  &--right {
+    right: 0;
+  }
+}
+
+/* Menu items with no JS */
+.app-button-menu__item {
+  display: inline-block;
+  width: auto; // Override NHS UK's 100% width
+  margin-right: nhsuk-spacing(2);
+  margin-bottom: nhsuk-spacing(2);
+  vertical-align: baseline;
+
+  &:last-child {
+    margin-right: 0;
+  }
+}
+
+.app-button-menu li {
+  margin: 0;
+}
+
+/* Menu items with JS */
+.app-button-menu li > .app-button-menu__item {
+  box-sizing: border-box;
+  display: inline-block;
+  position: relative;
+  width: 100%;
+  margin-top: 0;
+  margin-right: 0;
+  margin-bottom: 0;
+  margin-left: 0;
+  padding: nhsuk-spacing(2);
+  border: $nhsuk-border-width-form-element solid transparent;
+  // border-bottom: 1px solid $nhsuk-secondary-border-color;
+  border-bottom: 1px solid $nhsuk-form-border-color;
+  border-radius: 0;
+  color: $nhsuk-text-color;
+  background-color: $color_nhsuk-grey-5;
+  text-align: left;
+  vertical-align: top;
+  cursor: pointer;
+  -webkit-appearance: none;
+  appearance: none;
+  @include nhsuk-font(19, $line-height: 19px);
+
+  &:link,
+  &:visited,
+  &:active,
+  &:hover {
+    color: $nhsuk-text-color;
+    text-decoration: none;
+  }
+
+  &:active,
+  &:hover {
+    color: $color_nhsuk-white;
+  }
+
+  // Fix unwanted button padding in Firefox
+  &::-moz-focus-inner {
+    padding: 0;
+    border: 0;
+  }
+
+  &:hover {
+    background-color: $color_nhsuk-blue;
+  }
+
+  &:focus {
+    z-index: 10;
+    border-color: $nhsuk-focus-color;
+    outline: $nhsuk-focus-width solid transparent;
+    box-shadow: inset 0 0 0 1px $nhsuk-focus-color;
+  }
+
+  &:focus:not(:active):not(:hover) {
+    border-color: $nhsuk-focus-color;
+    color: $nhsuk-focus-text-color;
+    background-color: $nhsuk-focus-color;
+    box-shadow: 0 2px 0 $nhsuk-focus-text-color;
+  }
+}

--- a/app/assets/sass/main.scss
+++ b/app/assets/sass/main.scss
@@ -2,6 +2,7 @@
 @forward 'nhsuk-frontend/packages/nhsuk';
 
 // Components that are not in the NHS.UK frontend library
+@forward 'components/button-menu';
 @forward 'components/dark-mode';
 @forward 'components/list-border';
 @forward 'components/related-nav';

--- a/app/lib/utils/referrers.js
+++ b/app/lib/utils/referrers.js
@@ -56,7 +56,10 @@ const getReturnUrl = function(url, referrerChain) {
  */
 const urlWithReferrer = (url, referrerChain) => {
   if (!referrerChain) return url
-  return `${url}?referrerChain=${referrerChain}`
+
+  // Check if URL already has query parameters
+  const separator = url.includes('?') ? '&' : '?'
+  return `${url}${separator}referrerChain=${referrerChain}`
 }
 
 /**

--- a/app/routes/events.js
+++ b/app/routes/events.js
@@ -291,10 +291,11 @@ module.exports = router => {
   }
 
   // Save symptom - handles both 'save' and 'save and add another' with data cleanup
-  router.post('/clinics/:clinicId/events/:eventId/medical-information/symptoms/save', (req, res) => {
+  router.all('/clinics/:clinicId/events/:eventId/medical-information/symptoms/save', (req, res) => {
     const { clinicId, eventId } = req.params
     const data = req.session.data
-    const action = req.body.action // 'save' or 'save-and-add'
+    const action = req.body.action || req.query.action // 'save' or 'save-and-add'
+    const nextSymptomType = req.query.symptomType // camelCase symptom type
     const referrerChain = req.query.referrerChain
 
     // Save temp symptom to array
@@ -395,10 +396,17 @@ module.exports = router => {
       delete data.event.symptomTemp
     }
 
-    // Redirect based on action
+    // Redirect based on action and symptom type
     if (action === 'save-and-add') {
-      res.redirect(urlWithReferrer(`/clinics/${clinicId}/events/${eventId}/medical-information/symptoms/add`, referrerChain))
+      if (nextSymptomType) {
+        // Redirect to add specific symptom type
+        res.redirect(`/clinics/${clinicId}/events/${eventId}/medical-information/symptoms/add?symptomType=${nextSymptomType}${referrerChain ? '&referrerChain=' + referrerChain : ''}`)
+      } else {
+        // Fallback to general add page
+        res.redirect(urlWithReferrer(`/clinics/${clinicId}/events/${eventId}/medical-information/symptoms/add`, referrerChain))
+      }
     } else {
+      // Regular save - redirect back to medical information page
       const returnUrl = getReturnUrl(`/clinics/${clinicId}/events/${eventId}/record-medical-information`, referrerChain)
       res.redirect(returnUrl)
     }
@@ -453,8 +461,41 @@ module.exports = router => {
 
   // Main route in to starting an event - used to clear any temp data
   router.get('/clinics/:clinicId/events/:eventId/medical-information/symptoms/add', (req, res) => {
-    delete req.session.data.event.symptomTemp
-    res.redirect(urlWithReferrer(`/clinics/${req.params.clinicId}/events/${req.params.eventId}/medical-information/symptoms/type`, req.query.referrerChain))
+    const { clinicId, eventId } = req.params
+    const { symptomType } = req.query
+    console.log('Adding symptom type:', symptomType)
+    const data = req.session.data
+
+    // Clear any existing temp symptom data
+    delete data.event?.symptomTemp
+
+    // If symptomType is provided, pre-populate and go to details
+    if (symptomType) {
+      // Map camelCase symptom types to display names
+      const symptomTypeMap = {
+        'breastLump': 'Breast lump',
+        'swellingOrShapeChange': 'Swelling or shape change',
+        'skinChange': 'Skin change',
+        'nippleChange': 'Nipple change',
+        'persistentPain': 'Persistent pain',
+        'other': 'Other'
+      }
+
+      const fullSymptomType = symptomTypeMap[symptomType]
+
+      if (fullSymptomType) {
+        // Pre-populate symptomTemp with the selected type
+        data.event.symptomTemp = {
+          type: fullSymptomType
+        }
+
+        // Redirect to details page
+        return res.redirect(urlWithReferrer(`/clinics/${clinicId}/events/${eventId}/medical-information/symptoms/details`, req.query.referrerChain))
+      }
+    }
+
+    // No symptomType or invalid type - go to type selection page
+    res.redirect(urlWithReferrer(`/clinics/${clinicId}/events/${eventId}/medical-information/symptoms/type`, req.query.referrerChain))
   })
 
   const MAMMOGRAPHY_VIEWS = [

--- a/app/views/_components/button-menu/macro.njk
+++ b/app/views/_components/button-menu/macro.njk
@@ -1,0 +1,4 @@
+
+{% macro buttonMenu(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/app/views/_components/button-menu/template.njk
+++ b/app/views/_components/button-menu/template.njk
@@ -1,0 +1,50 @@
+{# Adapted from https://github.com/ministryofjustice/app-frontend/blob/main/src/app/components/button-menu/template.njk #}
+
+{# {%- from "govuk/components/button/macro.njk" import govukButton %} #}
+{% from 'button/macro.njk' import button %}
+
+{# {% from "govuk/macros/attributes.njk" import nhsukAttributes %} #}
+{% from "attributes.njk" import nhsukAttributes %}
+
+{#- Set classes for this component #}
+{%- set classNames = "app-button-menu" -%}
+{%- set defaultItemClassNames = "app-button-menu__item nhsuk-button--secondary" %}
+
+{%- if params.classes %}
+  {% set classNames = classNames + " " + params.classes %}
+{% endif %}
+
+{%- set buttonAttributes = {
+  "data-button-text": {
+    value: params.button.text,
+    optional: true
+    },
+  "data-button-classes": {
+    value: params.button.classes,
+    optional: true
+  },
+  "data-align-menu": {
+    value: params.alignMenu,
+    optional: true
+  }
+}
+%}
+
+<div class="{{- classNames -}}" data-module="app-button-menu" {{- nhsukAttributes(params.attributes) -}}  {{- nhsukAttributes(buttonAttributes) -}}>
+  {%- for item in params.items %}
+    {% set currentItemClassNames = " " + item.classes if item.classes else "" %}
+    {{ button({
+      element: item.element,
+      classes: defaultItemClassNames + currentItemClassNames,
+      text: item.text,
+      html: item.html,
+      name: item.name,
+      type: item.type,
+      value: item.value,
+      href: item.href,
+      disabled: item.disabled,
+      attributes: item.attributes,
+      preventDoubleClick: items.preventDoubleClick
+    }) }}
+  {% endfor -%}
+</div>

--- a/app/views/_includes/add-symptom-button-menu.njk
+++ b/app/views/_includes/add-symptom-button-menu.njk
@@ -1,0 +1,37 @@
+{% set methodUrl -%}
+  /clinics/{{ clinicId }}/events/{{ eventId }}/medical-information/symptoms
+{% endset %}
+
+{% if saveSymptomFirst == true %}
+  {% set methodUrl = methodUrl ~ "/save?action=save-and-add&symptomType=" %}
+{% else %}
+  {% set methodUrl = methodUrl ~ "/add?symptomType=" %}
+{% endif %}
+
+{% set symptoms = [
+  "Breast lump",
+  "Swelling or shape change",
+  "Skin change",
+  "Nipple change",
+  "Persistent pain",
+  "Other"
+] %}
+
+{% set buttonMenuItems = [] %}
+
+{% for symptom in symptoms %}
+  {% set buttonMenuItems = buttonMenuItems | push({
+    text: symptom,
+    href: (methodUrl ~ (symptom | camelCase) ) | urlWithReferrer(referrerChain),
+    classes: "nhsuk-button--secondary"
+  }) %}
+{% endfor %}
+
+{{ buttonMenu({
+  items: buttonMenuItems,
+  button: {
+    text: "Add another symptom" if hasSymptoms or (saveSymptomFirst == true) else "Add a symptom",
+    classes: "nhsuk-button--secondary"
+  },
+  alignMenu: "left"
+}) }}

--- a/app/views/_includes/cards/medical-information/symptoms.njk
+++ b/app/views/_includes/cards/medical-information/symptoms.njk
@@ -18,9 +18,13 @@
     {{ "./medical-information/symptoms/add" | urlWithReferrer(currentUrl) }}
   {% endset %}
 
-  <p class="nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0">
+  {# <p class="nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0">
     <a href="{{ linkHref }}" class="nhsuk-link">{{ "Add another symptom" if hasSymptoms else "Add a symptom" }}</a>
-  </p>
+  </p> #}
+
+  {# Explicitly set referrer chain to the current url #}
+  {% set referrerChain = currentUrl %}
+  {% include "add-symptom-button-menu.njk" %}
 {% endset %}
 
 {{ card({

--- a/app/views/_includes/scripts.html
+++ b/app/views/_includes/scripts.html
@@ -3,6 +3,7 @@
 {% if useAutoStoreData %}
   <script src="/js/auto-store-data.js"></script>
 {% endif %}
+<script src="/js/button-menu.js"></script>
 
 <!-- Add any custom scripts -->
 {% if data.settings.reading.showPacsViewer | falsify %}

--- a/app/views/_templates/layout.html
+++ b/app/views/_templates/layout.html
@@ -14,7 +14,7 @@
 
 {%- from '_components/notification-banner/macro.njk' import appNotificationBanner %}
 {%- from '_components/secondary-navigation/macro.njk' import appSecondaryNavigation %}
-
+{%- from '_components/button-menu/macro.njk' import buttonMenu %}
 
 <!-- Add your custom CSS or Sass in /app/assets/sass/main.scss -->
 {% block headCSS %}

--- a/app/views/events/mammography/medical-information/symptoms/details.html
+++ b/app/views/events/mammography/medical-information/symptoms/details.html
@@ -547,20 +547,25 @@
       }
     }) }}
 
-    {{ button({
+    {# {{ button({
       text: "Save and add another",
       classes: "nhsuk-button--secondary",
       attributes: {
         name: "action",
         value: "save-and-add"
       }
-    }) }}
+    }) }} #}
+    {% set saveSymptomFirst = true %}
+    {% include "add-symptom-button-menu.njk" %}
   </div>
 
   {# Only show link if this is a previously saved symptom #}
   {% if event.symptomTemp.id %}
+    {% set deleteHref %}
+      ./delete/{{ event.symptomTemp.id }}{{ "" | urlWithReferrer(referrerChain) }}
+    {% endset %}
     <p class="nhsuk-u-margin-top-4">
-      <a href="./delete/{{ event.symptomTemp.id }}" class="nhsuk-link app-link--warning">
+      <a href="{{ deleteHref }}" class="nhsuk-link app-link--warning">
         Delete this symptom
       </a>
     </p>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -80,6 +80,9 @@
   <li>
     <a href="/settings">Settings</a>
   </li>
+  <li>
+    <a href="/playground">Code playground</a>
+  </li>
 </ul>
 
 {% endblock %}


### PR DESCRIPTION
## Description
This adds a button-menu component ([adapted from the MOJ design system](https://design-patterns.service.justice.gov.uk/components/button-menu/)) and applies it to our symptom add journey to bypass the symptom type page.

The css needs work, but this is probably good enough to test.

![Video of button menu for adding a symptom. The button is clicked and a number of options are shown, each a different symptom. After picking a symptom the user is taken to a page about that symptom.](https://github.com/user-attachments/assets/3df4fe4a-5a2e-47f0-9d40-97c020e4b36b)

## Implementation thoughts
Without js this renders as 3 buttons. With js you *may* see a flash of these. If we were to build this in production I wonder about alternatives such as just rendering a single link (as we had it) which links to the symptom type page, or else three links.