### PR TITLE
Misc updates including screening history row and appointment actions

### DIFF
--- a/app/assets/sass/components/_button-menu.scss
+++ b/app/assets/sass/components/_button-menu.scss
@@ -94,7 +94,7 @@
   cursor: pointer;
   -webkit-appearance: none;
   appearance: none;
-  @include nhsuk-font(19, $line-height: 19px);
+  @include nhsuk-font(19);
 
   &:link,
   &:visited,

--- a/app/data/breast-screening-units.js
+++ b/app/data/breast-screening-units.js
@@ -17,7 +17,7 @@ module.exports = [
     clinicTypes: ['screening'],
     riskLevelHandling: [
       'routine',
-      'moderate',
+      'family history',
     ],
     // Default operating hours for the BSU
     sessionPatterns: [
@@ -46,7 +46,7 @@ module.exports = [
         // Main sites can handle all supported risk levels
         riskLevelHandling: [
           'routine',
-          'moderate',
+          'family history',
         ],
         address: {
           line1: 'Breast Screening Unit',

--- a/app/data/risk-levels.js
+++ b/app/data/risk-levels.js
@@ -10,7 +10,7 @@ module.exports = {
       lower: 50
     }
   },
-  moderate: {
+  "family history": {
     weight: 0.25,
     frequency: 12, // months
     ageRange: {

--- a/app/lib/generators/participant-generator.js
+++ b/app/lib/generators/participant-generator.js
@@ -264,8 +264,6 @@ const generateParticipant = ({
   // Determine risk level first as it affects age generation
   const participantRiskLevel = overrides?.config?.defaultRiskLevel || riskLevel || pickRiskLevel()
 
-  // const participantRiskLevel = 'moderate'
-
   // First get or generate BSU
   const assignedBSU = overrides?.assignedBSU
     ? breastScreeningUnits.find(bsu => bsu.id === overrides.assignedBSU)

--- a/app/lib/utils/participants.js
+++ b/app/lib/utils/participants.js
@@ -158,7 +158,7 @@ const getParticipantUpcomingClinics = (data, participantId) =>
 /**
  * Determine a participant's current risk level based on age and risk factors
  * @param {Object} participant - Participant object
- * @returns {string} Current risk level (routine, moderate, or high)
+ * @returns {string} Current risk level (routine, family history, or high)
  */
 const getCurrentRiskLevel = (participant, referenceDate = new Date()) => {
   const age = getAge(participant, referenceDate)
@@ -169,10 +169,10 @@ const getCurrentRiskLevel = (participant, referenceDate = new Date()) => {
     return 'routine'
   }
 
-  // Check if they're in the moderate risk age range
-  const moderateRange = riskLevels.moderate.ageRange
-  if (age >= moderateRange.lower && age < moderateRange.upper) {
-    return 'moderate'
+  // Check if they're in the family history risk age range
+  const familyHistoryRange = riskLevels['family history'].ageRange
+  if (age >= familyHistoryRange.lower && age < familyHistoryRange.upper) {
+    return 'family history'
   }
 
   // Check if they're in the high risk age range

--- a/app/views/_includes/event-header.njk
+++ b/app/views/_includes/event-header.njk
@@ -19,15 +19,47 @@
 
   <div class="app-header-with-status__status-tag">
     {{ statusHtml | safe }}
+    <br>
+    {{ buttonMenu({
+      items: [
+
+        {
+          text: "Reschedule appointment",
+          href: "#" | urlWithReferrer(currentUrl),
+          classes: "nhsuk-button--secondary"
+        },
+        {
+          text: "Cancel appointment",
+          href: "#" | urlWithReferrer(currentUrl),
+          classes: "nhsuk-button--secondary"
+        },
+        {
+          text: "Make this appointment a special appointment" if not event.details.isSpecialAppointment else "Change special appointment details",
+          href: "#" | urlWithReferrer(currentUrl),
+          classes: "nhsuk-button--secondary"
+        }
+      ],
+      button: {
+        text: "Appointment actions",
+        classes: "nhsuk-button--secondary"
+      },
+      alignMenu: "right"
+    }) }}
   </div>
 </div>
 
+<p class="app-text-grey">
+  <span>NHS Number: {{ participant.medicalInformation.nhsNumber | formatNhsNumber }}</span>
+  {# <span class="nhsuk-u-margin-left-4">SX Number: {{ participant.sxNumber }}</span> #}
+</p>
 
-<p class="app-text-grey"><span>NHS Number: {{ participant.medicalInformation.nhsNumber | formatNhsNumber }}</span><span class="nhsuk-u-margin-left-4">SX Number: {{ participant.sxNumber }}</span></p>
+{{ appointmentTimeHtml }}
 
-{{appointmentTimeHtml}}
-
-<p>{{ event.timing.startTime | formatTimeString }} ({{ event.timing.duration }} minutes) - {{ clinic.date | formatDate }} ({{ clinic.date | formatRelativeDate }})<span class="nhsuk-u-margin-left-3"><a href="#">Reschedule appointment</a></span></p>
+<p>{{ event.timing.startTime | formatTimeString }} ({{ event.timing.duration }} minutes) - {{ clinic.date | formatDate }} ({{ clinic.date | formatRelativeDate }})
+  {# <span class="nhsuk-u-margin-left-3">
+    <a href="#">Reschedule appointment</a>
+  </span> #}
+</p>
 
 <p class="nhsuk-u-margin-bottom-4"><a href="{{ '/participants/' + participant.id | urlWithReferrer(currentUrl) }}">View participant record</a></p>
 

--- a/app/views/_includes/summary-lists/participant.njk
+++ b/app/views/_includes/summary-lists/participant.njk
@@ -116,6 +116,12 @@
 
 {% endset %}
 
+{% set riskLevel = participant | getCurrentRiskLevel | sentenceCase %}
+
+{% if riskLevel == "Family history" %}
+  {% set riskLevel = "Family history: moderate risk" %}
+{% endif %}
+
 {{ summaryList({
   rows: [
    {
@@ -276,20 +282,20 @@
    },
    {
      key: {
-       text: "Risk level"
+       text: "Screening protocol"
      },
      value: {
-       html: participant | getCurrentRiskLevel | sentenceCase
+       text: riskLevel
      },
      actions: {
         items: [
           {
             href: "#",
             text: "View or update screening history",
-            visuallyHiddenText: "email"
+            visuallyHiddenText: "screening protocol"
           } if false
         ]
       }
-   } if false
+   }
   ]
 } | showMissingInformationLink) }}

--- a/app/views/events/show.html
+++ b/app/views/events/show.html
@@ -7,6 +7,9 @@
 
 {% set gridColumn = "nhsuk-grid-column-full" %}
 
+{# Todo: should these get set by middleware? #}
+{% set isFinal = event | isFinal %}
+{% set isCompleted = event | isCompleted %}
 
 {% set back = {
   href: "/clinics/" + clinicId,
@@ -24,7 +27,7 @@
   {% set activeTab = 'all' %}
 
   {# Show tabs if we've done mammography #}
-  {% if ['event_complete', 'event_partially_screened'] | includes(event.status) %}
+  {% if isCompleted %}
     {% include "event-navigation.njk" %}
   {% endif %}
 

--- a/app/views/participants/show.html
+++ b/app/views/participants/show.html
@@ -15,14 +15,15 @@
 
 {% block pageContent %}
 
-  {{ participant | log }}
-  {{ event | log }}
+  {{ participant | log("Participant") }}
+  {{ event | log("Event") }}
 
   <h1 class="nhsuk-heading-l">
-    {{ pageHeading }}
+    <span class="nhsuk-caption-l">
+      Participant record
+    </span>
+    {{ pageHeading | safe }}
   </h1>
-
-  {{ screeningHistoryHtml | safe }}
 
   {% set personalDetailsHtml %}
     {% include "summary-lists/participant.njk" %}
@@ -33,26 +34,6 @@
     headingLevel: "2",
     descriptionHtml: personalDetailsHtml
   }) }}
-
-  {# {% set screeningHistoryHtml %}
-
-    {% set lastMammogramDateHtml %}
-      {% set lastMammogramDate = "2021-12-27T12:54:27.756Z" %}
-      {{ lastMammogramDate | formatDate }}<br>
-      <span class="nhsuk-hint">({{ lastMammogramDate | formatRelativeDate }})</span>
-    {% endset %}
-
-    {{ summaryList({
-      rows: [
-        {
-          key: { text: "Date of last mammogram" },
-          value: {
-            html: lastMammogramDateHtml
-          }
-        }
-      ] | removeEmpty
-    }) }}
-  {% endset %} #}
 
   {% set screeningHistoryHtml %}
     {% include "summary-lists/screening-history.njk" %}

--- a/app/views/playground.html
+++ b/app/views/playground.html
@@ -1,0 +1,21 @@
+{# app/views/dashboard.html #}
+
+{% extends 'layout-app.html' %}
+
+{% set pageHeading = "Playground" %}
+
+{% set gridColumn = "nhsuk-grid-column-full" %}
+
+{% set hideBackLink = true %}
+
+{% set navActive = "home" %}
+
+{% block pageContent %}
+
+<h1>
+  {{pageHeading}}
+</h1>
+
+<p class="nhsuk-body-l">This is not a user facing page. Use this for quick testing of code.</p>
+
+{% endblock %}


### PR DESCRIPTION
Changes:

* Restores the risk level row to the appointment record, but renamed as 'Screening protocol'.
* No longer refers to 'moderate' risk, but instead 'family history'
* Adds button menu for appointment actions (currently non-functional)
* Adds playground page for quick testing of html
* Removes SX number from display on the appointment record