### PR TITLE
Initial work on confirmation pages and contact details edit

### DIFF
--- a/app/lib/generators/address-generator.js
+++ b/app/lib/generators/address-generator.js
@@ -197,7 +197,7 @@ const generateBSUAppropriateAddress = (bsu) => {
   return {
     ...addressLine1,
     line2,
-    city: faker.helpers.arrayElement(nearbyAreas),
+    town: faker.helpers.arrayElement(nearbyAreas),
     postcode: generateNearbyPostcode(bsu.address.postcode),
   }
 }

--- a/app/lib/utils/arrays.js
+++ b/app/lib/utils/arrays.js
@@ -107,6 +107,29 @@ const removeWhere = (array, key, compare) => {
   })
 }
 
+/**
+ * Apply a filter to each element in an array
+ * @param {Array} array - Array to map over
+ * @param {string} filterName - Name of the filter to apply to each element
+ * @returns {Array} New array with filter applied to each element
+ */
+const map = function(array, filterName) {
+  if (!array || !Array.isArray(array)) return []
+
+  // In Nunjucks filter context, 'this' gives us access to the environment
+  // and we can access other filters through the environment
+  const env = this.env
+
+  if (!env || !env.filters || !env.filters[filterName]) {
+    console.warn(`Filter '${filterName}' not found`)
+    return array
+  }
+
+  const filterFunction = env.filters[filterName]
+
+  return array.map(item => filterFunction.call(this, item))
+}
+
 module.exports = {
   push,
   includes,
@@ -115,4 +138,5 @@ module.exports = {
   findById,
   where,
   removeWhere,
+  map,
 }

--- a/app/lib/utils/dynamic-routing.js
+++ b/app/lib/utils/dynamic-routing.js
@@ -1,0 +1,59 @@
+// app/lib/utils/dynamic-routing.js
+
+/**
+ * Create a simple dynamic route handler that just attempts template rendering
+ * Assumes all data is already set up in res.locals by middleware
+ * @param {Object} options - Configuration options
+ * @param {string} options.templatePrefix - Template path prefix (e.g., 'participants')
+ * @returns {Function} Express route handler
+ */
+const createDynamicTemplateRoute = (options) => {
+  const { templatePrefix } = options
+
+  return (req, res, next) => {
+    const subPath = req.params[0] // Get the wildcard path
+
+    console.log(`Dynamic route attempting to render: ${templatePrefix}/${subPath}`)
+
+    // Try to render {templatePrefix}/{subPath}
+    const templatePath = `${templatePrefix}/${subPath}`
+
+    res.render(templatePath, (error, html) => {
+      if (!error) {
+        console.log(`Successfully rendered: ${templatePath}`)
+        res.set({ 'Content-type': 'text/html; charset=utf-8' })
+        res.end(html)
+        return
+      }
+      if (!error.message.startsWith('template not found')) {
+        console.log(`Error rendering ${templatePath}:`, error.message)
+        next(error)
+        return
+      }
+
+      console.log(`Template not found: ${templatePath}, trying index variant`)
+
+      // Try with /index if the path doesn't already end with /index
+      if (!subPath.endsWith('/index')) {
+        const indexPath = `${templatePrefix}/${subPath}/index`
+        res.render(indexPath, (indexError, indexHtml) => {
+          if (!indexError) {
+            console.log(`Successfully rendered: ${indexPath}`)
+            res.set({ 'Content-type': 'text/html; charset=utf-8' })
+            res.end(indexHtml)
+            return
+          }
+          console.log(`Template not found: ${indexPath}`)
+          next() // Template not found, let other routes handle it or trigger 404
+        })
+        return
+      }
+      console.log(`No template found for: ${templatePrefix}/${subPath}`)
+      next() // Template not found
+    })
+  }
+}
+
+module.exports = {
+  createDynamicTemplateRoute
+}

--- a/app/lib/utils/objects.js
+++ b/app/lib/utils/objects.js
@@ -45,7 +45,7 @@ const getObjectValues = (obj, options = {}) => {
 
   // Remove empty values if specified
   if (removeEmpty) {
-    values = values.filter(val => val !== null && val !== undefined)
+    values = values.filter(val => Boolean(val))
   }
 
   return values

--- a/app/lib/utils/strings.js
+++ b/app/lib/utils/strings.js
@@ -173,6 +173,17 @@ const startsWith = (input, target) => {
 }
 
 /**
+ * Check if string contains substring
+ * @param {string} input - String to search in
+ * @param {string} target - Substring to look for
+ * @returns {boolean} Whether string contains substring
+ */
+const stringIncludes = (input, target) => {
+  if (typeof input !== 'string' || typeof target !== 'string') return false
+  return input.includes(target)
+}
+
+/**
  * Check if value is a string
  * @param {any} input - Value to check
  * @returns {boolean} Whether value is a string
@@ -321,6 +332,7 @@ module.exports = {
   split,
   startLowerCase,
   startsWith,
+  stringIncludes,
   stringLiteral,
   formatPhoneNumber,
   pluralise

--- a/app/lib/utils/summary-list.js
+++ b/app/lib/utils/summary-list.js
@@ -15,41 +15,63 @@ const isEmpty = (value) => {
 }
 
 /**
- * Convert value object to "Enter X" link if empty
- * @param {Object} row - Summary list row
- * @returns {Object} Modified row with enter link if empty
+ * Convert value object to "Enter X" link if empty, or show "Not provided"
+ * @param {Object} input - Summary list object or individual row object
+ * @param {boolean} showNotProvidedText - If true, show "Not provided" and keep actions. If false (default), show "Enter X" link
+ * @returns {Object} Modified summary list or row with enter link or "Not provided" if empty
  */
-const showMissingInformationLink = (summaryList) => {
-  if (!summaryList?.rows) return summaryList
+const handleSummaryListMissingInformation = (input, showNotProvidedText = false) => {
+  if (!input) return input
 
-  const updatedRows = summaryList.rows.map(row => {
-
+  // Helper function to process a single row
+  const processRow = (row) => {
     const value = row.value?.text || row.value?.html
     const hasAction = row.actions && row.actions.items && row.actions.items.length > 0
 
     // If value is not empty or there are no existing actions, return row as is
-    if (!isEmpty(value) || (!hasAction)) return row
+    if (!isEmpty(value) || !hasAction) return row
 
-    const keyText = row.actions?.items?.[0]?.visuallyHiddenText || row.key.text.toLowerCase()
-    const href = row.actions?.items?.[0]?.href || '#'
+    if (showNotProvidedText) {
+      // Show "Not provided" in grey and keep actions
+      return {
+        ...row,
+        value: {
+          html: `<span class="app-text-grey">Not provided</span>`
+        }
+        // Keep existing actions
+      }
+    } else {
+      // Default behavior - show "Enter X" link and remove actions
+      const keyText = row.actions?.items?.[0]?.visuallyHiddenText || row.key.text.toLowerCase()
+      const href = row.actions?.items?.[0]?.href || '#'
 
-    return {
-      ...row,
-      value: {
-        html: `<a href="${href}" class="nhsuk-link">Enter ${keyText} details</a>`
-      },
-      actions: {
-        items: []
+      return {
+        ...row,
+        value: {
+          html: `<a href="${href}" class="nhsuk-link">Enter ${keyText} details</a>`
+        },
+        actions: {
+          items: []
+        }
       }
     }
-  })
-
-  return {
-    ...summaryList,
-    rows: updatedRows
   }
+
+  // Check if input is a summary list (has rows property)
+  if (input.rows && Array.isArray(input.rows)) {
+    const updatedRows = input.rows.map(processRow)
+
+    return {
+      ...input,
+      rows: updatedRows
+    }
+  }
+
+  // Otherwise treat as single row object
+  return processRow(input)
 }
 
+
 module.exports = {
-  showMissingInformationLink
+  handleSummaryListMissingInformation
 }

--- a/app/routes/events.js
+++ b/app/routes/events.js
@@ -97,6 +97,7 @@ module.exports = router => {
     res.locals.clinic = originalEventData.clinic
 
     res.locals.participant = data.participant
+    res.locals.eventUrl = `/clinics/${clinicId}/events/${eventId}`
     res.locals.unit = originalEventData.unit
     res.locals.clinicId = clinicId
     res.locals.eventId = eventId

--- a/app/routes/events.js
+++ b/app/routes/events.js
@@ -98,6 +98,7 @@ module.exports = router => {
 
     res.locals.participant = data.participant
     res.locals.eventUrl = `/clinics/${clinicId}/events/${eventId}`
+    res.locals.contextUrl = `/clinics/${clinicId}/events/${eventId}`
     res.locals.unit = originalEventData.unit
     res.locals.clinicId = clinicId
     res.locals.eventId = eventId

--- a/app/routes/participants.js
+++ b/app/routes/participants.js
@@ -2,8 +2,13 @@
 
 const { getParticipant, sortBySurname, getParticipantClinicHistory } = require('../lib/utils/participants')
 const { findById } = require('../lib/utils/arrays')
+const { createDynamicTemplateRoute } = require('../lib/utils/dynamic-routing')
+
 
 module.exports = router => {
+
+
+
 // Set clinics to active in nav for all urls starting with /clinics
   router.use('/participants', (req, res, next) => {
     res.locals.navActive = 'participants'
@@ -56,23 +61,58 @@ module.exports = router => {
     })
   })
 
-  // In the show route:
-  router.get('/participants/:participantId', (req, res) => {
-    const data = req.session.data
+  router.use('/participants/:participantId', (req, res, next) => {
     const participantId = req.params.participantId
-    const participant = getParticipant(data, participantId)
+    const data = req.session.data
 
-    if (!participant) {
+    // console.log(`Looking up participant: ${participantId}`)
+
+    const originalParticipant = getParticipant(data, participantId)
+
+    if (!originalParticipant) {
+      console.log(`No participant ${participantId} found`)
       res.redirect('/participants')
       return
     }
 
-    const clinicHistory = getParticipantClinicHistory(data, participant.id)
+    // console.log(`Found participant: ${originalParticipant.demographicInformation.firstName} ${originalParticipant.demographicInformation.lastName}`)
 
-    res.render('participants/show', {
-      participant,
-      participantId,
-      clinicHistory,
-    })
+    // We store a temporary copy of the participant to session for use by forms
+    // If it doesn't exist, create it now
+    if (!data.participant || (data.participant?.id !== participantId)) {
+      if (!data.participant) {
+        console.log('No temp participant data found, creating new one')
+      }
+      else if (data.participant?.id !== participantId) {
+        console.log(`Temp participant data found, but participantId ${data.participant.id} does not match ${participantId}, creating new one`)
+      }
+      // Copy over the participant data to the temp participant
+      data.participant = { ...originalParticipant }
+    }
+
+    // This will now have any temp participant data that forms have added too
+    // We'll later save this back to the source data using saveTempParticipantToParticipant
+    res.locals.participant = data.participant
+    res.locals.participantId = participantId
+
+    res.locals.participantUrl = `/participants/${participantId}`
+
+    // Store original participant data for reference if needed
+    res.locals.originalParticipant = originalParticipant
+
+    // Get additional data that participant pages might need
+    const clinicHistory = getParticipantClinicHistory(data, originalParticipant.id)
+    res.locals.clinicHistory = clinicHistory
+
+    next()
   })
+
+  router.get('/participants/:participantId', (req, res) => {
+    res.render('participants/show')
+  })
+
+  router.get('/participants/:participantId/*', createDynamicTemplateRoute({
+    templatePrefix: 'participants'
+  }))
+
 }

--- a/app/routes/participants.js
+++ b/app/routes/participants.js
@@ -1,8 +1,9 @@
 // app/routes/participants.js
 
-const { getParticipant, sortBySurname, getParticipantClinicHistory } = require('../lib/utils/participants')
+const { getParticipant, sortBySurname, getParticipantClinicHistory, saveTempParticipantToParticipant } = require('../lib/utils/participants')
 const { findById } = require('../lib/utils/arrays')
 const { createDynamicTemplateRoute } = require('../lib/utils/dynamic-routing')
+const { getReturnUrl, urlWithReferrer, appendReferrer } = require('../lib/utils/referrers')
 
 
 module.exports = router => {
@@ -114,5 +115,16 @@ module.exports = router => {
   router.get('/participants/:participantId/*', createDynamicTemplateRoute({
     templatePrefix: 'participants'
   }))
+
+  router.post('/participants/:participantId/save', (req, res) => {
+    const data = req.session.data
+    const participantId = req.params.participantId
+    const referrerChain = req.query.referrerChain
+    saveTempParticipantToParticipant(data)
+
+    // Redirect back to the participant page
+    const returnUrl = getReturnUrl(`/participants/${participantId}`, referrerChain)
+    res.redirect(returnUrl)
+  })
 
 }

--- a/app/routes/participants.js
+++ b/app/routes/participants.js
@@ -97,6 +97,7 @@ module.exports = router => {
     res.locals.participantId = participantId
 
     res.locals.participantUrl = `/participants/${participantId}`
+    res.locals.contextUrl = `/participants/${participantId}`
 
     // Store original participant data for reference if needed
     res.locals.originalParticipant = originalParticipant

--- a/app/views/_components/summary-list/macro.njk
+++ b/app/views/_components/summary-list/macro.njk
@@ -1,0 +1,20 @@
+{% macro appSummaryList(params) %}
+  {# Decide whether to use native component or our patched version #}
+  {# Iterates through each row, checking if any are html - if so, we need ours #}
+  {% set canUseNativeComponent = true %}
+  {% for row in params.rows %}
+    {% if row.html %}
+      {% set canUseNativeComponent = false %}
+    {% endif %}
+  {% endfor %}
+  {% if canUseNativeComponent %}
+    {% from "summary-list/macro.njk" import summaryList %}
+    {{ summaryList(params) }}
+  {% else %}
+    {%- include "./summary-list-template.njk" -%}
+  {% endif %}
+{% endmacro %}
+
+{% macro appSummaryListRow(row) %}
+  {%- include "./summary-list-row-template.njk" -%}
+{% endmacro %}

--- a/app/views/_components/summary-list/summary-list-row-template.njk
+++ b/app/views/_components/summary-list/summary-list-row-template.njk
@@ -1,0 +1,42 @@
+{% from "attributes.njk" import nhsukAttributes %}
+
+{%- macro _link(action) %}
+  <a href="{{ action.href }}">
+    {{ action.html | safe if action.html else action.text }}
+    {%- if action.visuallyHiddenText -%}
+      <span class="nhsuk-u-visually-hidden"> {{ action.visuallyHiddenText }}</span>
+    {% endif -%}
+  </a>
+{% endmacro -%}
+
+{#- Determine if we need 2 or 3 columns #}
+{# Unlike the native one we can't iterate through all rows, so we just default to
+true unless told otherwise #}
+{%- set anyRowHasActions = row.anyRowHasActions | default(true) %}
+
+{% if row %}
+  <div class="nhsuk-summary-list__row {%- if anyRowHasActions and not row.actions.items %} nhsuk-summary-list__row--no-actions{% endif %} {%- if row.classes %} {{ row.classes }}{% endif %}">
+    <dt class="nhsuk-summary-list__key {%- if row.key.classes %} {{ row.key.classes }}{% endif %}">
+      {{ row.key.html | safe if row.key.html else row.key.text }}
+    </dt>
+    <dd class="nhsuk-summary-list__value {%- if row.value.classes %} {{ row.value.classes }}{% endif %}">
+      {{ row.value.html | indent(8) | trim | safe if row.value.html else row.value.text }}
+    </dd>
+    {% if row.actions.items %}
+      <dd class="nhsuk-summary-list__actions {%- if row.actions.classes %} {{ row.actions.classes }}{% endif %}">
+        {% if row.actions.items.length == 1 %}
+          {{ _link(row.actions.items[0]) | indent(12) | trim }}
+        {% else %}
+          <ul class="nhsuk-summary-list__actions-list">
+            {% for action in row.actions.items %}
+              <li class="nhsuk-summary-list__actions-list-item">
+                {{ _link(action) | indent(18) | trim }}
+              </li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+      </dd>
+    {% endif %}
+  </div>
+{% endif %}
+

--- a/app/views/_components/summary-list/summary-list-template.njk
+++ b/app/views/_components/summary-list/summary-list-template.njk
@@ -1,0 +1,64 @@
+{# From https://github.com/nhsuk/nhsuk-frontend/blob/main/packages/nhsuk-frontend/src/nhsuk/components/summary-list/template.njk #}
+
+{# Adapted from default component so that rows can be passed in as html rather than data #}
+
+{% from "attributes.njk" import nhsukAttributes %}
+
+{%- macro _link(action) %}
+  <a href="{{ action.href }}">
+    {{ action.html | safe if action.html else action.text }}
+    {%- if action.visuallyHiddenText -%}
+      <span class="nhsuk-u-visually-hidden"> {{ action.visuallyHiddenText }}</span>
+    {% endif -%}
+  </a>
+{% endmacro -%}
+
+{#- Determine if we need 2 or 3 columns #}
+{%- set anyRowHasActions = false %}
+{% for row in params.rows %}
+  {% if row.html %}
+    {# If the row has an actions class, we assume it has actions #}
+    {{ "Row has actions" | log("Row has actions") }}
+    {% set anyRowHasActions = true if row.html | stringIncludes("nhsuk-summary-list__actions") %}
+  {% else %}
+    {% set anyRowHasActions = true if row.actions.items | length else anyRowHasActions %}
+  {% endif %}
+
+{% endfor -%}
+
+<dl class="nhsuk-summary-list {%- if params.classes %} {{ params.classes }}{% endif %}" {{- nhsukAttributes(params.attributes) }}>
+  {% for row in params.rows %}
+    {% if row %}
+      {# Check if row is pure html, if so just render it #}
+      {% if row.html %}
+        {{ row.html | indent(4) | trim | safe }}
+      {# Render default row #}
+      {% else %}
+        <div class="nhsuk-summary-list__row {%- if anyRowHasActions and not row.actions.items %} nhsuk-summary-list__row--no-actions{% endif %} {%- if row.classes %} {{ row.classes }}{% endif %}">
+          <dt class="nhsuk-summary-list__key {%- if row.key.classes %} {{ row.key.classes }}{% endif %}">
+            {{ row.key.html | safe if row.key.html else row.key.text }}
+          </dt>
+          <dd class="nhsuk-summary-list__value {%- if row.value.classes %} {{ row.value.classes }}{% endif %}">
+            {{ row.value.html | indent(8) | trim | safe if row.value.html else row.value.text }}
+          </dd>
+          {% if row.actions.items %}
+            <dd class="nhsuk-summary-list__actions {%- if row.actions.classes %} {{ row.actions.classes }}{% endif %}">
+              {% if row.actions.items.length == 1 %}
+                {{ _link(row.actions.items[0]) | indent(12) | trim }}
+              {% else %}
+                <ul class="nhsuk-summary-list__actions-list">
+                  {% for action in row.actions.items %}
+                    <li class="nhsuk-summary-list__actions-list-item">
+                      {{ _link(action) | indent(18) | trim }}
+                    </li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
+            </dd>
+          {% endif %}
+        </div>
+      {% endif %}
+
+    {% endif %}
+  {% endfor %}
+</dl>

--- a/app/views/_includes/cards/medical-information/medical-information.njk
+++ b/app/views/_includes/cards/medical-information/medical-information.njk
@@ -53,7 +53,7 @@
           }
         }
       ]
-    } | showMissingInformationLink) }}
+    } | handleSummaryListMissingInformation) }}
   {% endset %}
 
   {{ card({

--- a/app/views/_includes/cards/medical-information/other-information.njk
+++ b/app/views/_includes/cards/medical-information/other-information.njk
@@ -118,7 +118,7 @@
         }
       }
     ]
-  } | showMissingInformationLink ) }}
+  } | handleSummaryListMissingInformation ) }}
 {% endset %}
 
 {{ card({

--- a/app/views/_includes/forms/contact-details.njk
+++ b/app/views/_includes/forms/contact-details.njk
@@ -43,8 +43,8 @@
     },
     classes: "nhsuk-u-width-two-thirds",
     id: "address-town",
-    value: participant.demographicInformation.address.city,
-    name: "participant[demographicInformation][address][city]"
+    value: participant.demographicInformation.address.town,
+    name: "participant[demographicInformation][address][town]"
   }) }}
 
   {# {{ input({

--- a/app/views/_includes/forms/contact-details.njk
+++ b/app/views/_includes/forms/contact-details.njk
@@ -1,0 +1,108 @@
+{# Home address #}
+{% call fieldset({
+  legend: {
+    text: "Home address",
+    classes: "nhsuk-fieldset__legend--m",
+    isPageHeading: true
+  }
+}) %}
+
+  {{ input({
+    label: {
+      html: 'Building and street <span class="nhsuk-u-visually-hidden">line 1 of 3</span>'
+    },
+    id: "address-line-1",
+    value: participant.demographicInformation.address.line1,
+    name: "participant[demographicInformation][address][line1]",
+    classes: "nhsuk-u-width-two-thirds"
+  }) }}
+
+  {{ input({
+    label: {
+      html: '<span class="nhsuk-u-visually-hidden">Building and street line 2 of 3</span>'
+    },
+    id: "address-line-2",
+    value: participant.demographicInformation.address.line2,
+    name: "participant[demographicInformation][address][line2]",
+    classes: "nhsuk-u-width-two-thirds"
+  }) }}
+
+  {{ input({
+    label: {
+      html: '<span class="nhsuk-u-visually-hidden">Building and street line 3 of 3</span>'
+    },
+    id: "address-line-3",
+    value: participant.demographicInformation.address.line3,
+    name: "participant[demographicInformation][address][line3]",
+    classes: "nhsuk-u-width-two-thirds"
+  }) }}
+
+  {{ input({
+    label: {
+      text: "Town or city"
+    },
+    classes: "nhsuk-u-width-two-thirds",
+    id: "address-town",
+    value: participant.demographicInformation.address.city,
+    name: "participant[demographicInformation][address][city]"
+  }) }}
+
+  {# {{ input({
+    label: {
+      text: "County"
+    },
+    classes: "nhsuk-u-width-two-thirds",
+    id: "address-county",
+    name: "participant[demographicInformation][address][address-county]"
+  }) }} #}
+
+  {{ input({
+    label: {
+      text: "Postcode"
+    },
+    classes: "nhsuk-input--width-10",
+    id: "address-postcode",
+    value: participant.demographicInformation.address.postcode,
+    name: "participant[demographicInformation][address][postcode]"
+  }) }}
+
+{% endcall %}
+
+{# Phone number #}
+
+<h2>Contact numbers</h2>
+
+{{ input({
+  label: {
+    text: "Mobile (optional)",
+    _classes: "nhsuk-label--m"
+  },
+  value: participant.demographicInformation.mobilePhone,
+  id: "mobile-phone-number",
+  name: "participant[demographicInformation][mobilePhone]",
+  classes: "nhsuk-u-width-one-half"
+}) }}
+
+
+{{ input({
+  label: {
+    text: "Home (optional)",
+    _classes: "nhsuk-label--m"
+  },
+  value: participant.demographicInformation.homePhone,
+  id: "home-phone-number",
+  name: "participant[demographicInformation][homePhone]",
+  classes: "nhsuk-u-width-one-half"
+}) }}
+
+{# Email address #}
+{{ input({
+  label: {
+    text: "Email address",
+    classes: "nhsuk-label--m"
+  },
+  value: participant.demographicInformation.email,
+  id: "email-address",
+  name: "participant[demographicInformation][email]",
+  classes: "nhsuk-u-width-two-thirds"
+}) }}

--- a/app/views/_includes/forms/contact-details.njk
+++ b/app/views/_includes/forms/contact-details.njk
@@ -98,7 +98,7 @@
 {# Email address #}
 {{ input({
   label: {
-    text: "Email address",
+    text: "Email address (optional)",
     classes: "nhsuk-label--m"
   },
   value: participant.demographicInformation.email,

--- a/app/views/_includes/summary-lists/demographic-information/contact-details.njk
+++ b/app/views/_includes/summary-lists/demographic-information/contact-details.njk
@@ -1,0 +1,25 @@
+{% set addressRow %}
+  {% include "../rows/address.njk" %}
+{% endset %}
+
+{% set phoneNumbersRow %}
+  {% include "../rows/phone-numbers.njk" %}
+{% endset %}
+
+{% set emailRow %}
+  {% include "../rows/email.njk" %}
+{% endset %}
+
+{{ summaryList({
+  rows: [
+    {
+      html: addressRow
+    },
+    {
+      html: phoneNumbersRow
+    },
+    {
+      html: emailRow
+    }
+  ]
+}) }}

--- a/app/views/_includes/summary-lists/participant.njk
+++ b/app/views/_includes/summary-lists/participant.njk
@@ -270,4 +270,4 @@
       }
    }
   ]
-} | showMissingInformationLink) }}
+} | handleSummaryListMissingInformation) }}

--- a/app/views/_includes/summary-lists/participant.njk
+++ b/app/views/_includes/summary-lists/participant.njk
@@ -6,15 +6,6 @@
   <span class="nhsuk-hint">({{ participant.demographicInformation.dateOfBirth | formatRelativeDate(true) }} old)</span>
 {% endset %}
 
-{% set address %}
-  {{ participant.demographicInformation.address.line1 }}<br>
-  {% if participant.demographicInformation.address.line2 %}
-    {{ participant.demographicInformation.address.line2 }}<br>
-  {% endif %}
-  {{ participant.demographicInformation.address.town }}<br>
-  {{ participant.demographicInformation.address.postcode }}
-{% endset %}
-
 {% set ethnicGroup = participant.demographicInformation.ethnicGroup %}
 {% set ethnicBackground = participant.demographicInformation.ethnicBackground %}
 {% set otherEthnicBackgroundDetails = participant.demographicInformation.otherEthnicBackgroundDetails %}
@@ -34,12 +25,16 @@
   {% endif %}
 {% endset %}
 
-{% set phoneHtml %}
-  {{ participant.demographicInformation.mobilePhone | formatPhoneNumber }}
-  {% if participant.demographicInformation.homePhone and participant.demographicInformation.mobilePhone %}
-    <br>
-  {% endif %}
-  {{ participant.demographicInformation.homePhone | formatPhoneNumber }}
+{% set addressRow %}
+  {% include "_includes/summary-lists/rows/address.njk" %}
+{% endset %}
+
+{% set phoneNumbersRow %}
+  {% include "_includes/summary-lists/rows/phone-numbers.njk" %}
+{% endset %}
+
+{% set emailRow %}
+  {% include "_includes/summary-lists/rows/email.njk" %}
 {% endset %}
 
 {% set hasAdditionalMammograms = event.previousMammograms | length > 0 %}
@@ -123,11 +118,6 @@
 {% if riskLevel == "Family history" %}
   {% set riskLevel = "Family history: moderate risk" %}
 {% endif %}
-
-{% set testArray = [0] %}
-
-
-{{ testArray | log("testArray") }}
 
 {{ summaryList({
   rows: [
@@ -219,38 +209,13 @@
       }
    },
    {
-     key: {
-       text: "Home address"
-     },
-     value: {
-       html: address
-     },
-     actions: {
-        items: [
-          {
-            href: participantId ~ "/personal-details/contact-details",
-            text: "Change",
-            visuallyHiddenText: "address"
-          } if allowEdits
-        ]
-      }
+     html: addressRow
    },
    {
-     key: {
-       text: "Phone"
-     },
-     value: {
-       html: phoneHtml
-     },
-     actions: {
-        items: [
-          {
-            href: participantId ~ "/personal-details/contact-details",
-            text: "Change",
-            visuallyHiddenText: "phone"
-          } if allowEdits
-        ]
-      }
+     html: phoneNumbersRow
+   },
+   {
+     html: emailRow
    },
    {
      key: {
@@ -268,7 +233,7 @@
           } if allowEdits
         ]
       }
-   },
+   } if false,
    {
      key: {
        text: "Last known mammogram" if not hasAdditionalMammograms else "Last known mammograms"

--- a/app/views/_includes/summary-lists/participant.njk
+++ b/app/views/_includes/summary-lists/participant.njk
@@ -35,6 +35,14 @@
   {% endif %}
 {% endset %}
 
+{% set phoneHtml %}
+  {{ participant.demographicInformation.mobilePhone | formatPhoneNumber }}
+  {% if participant.demographicInformation.homePhone and participant.demographicInformation.mobilePhone %}
+    <br>
+  {% endif %}
+  {{ participant.demographicInformation.homePhone | formatPhoneNumber }}
+{% endset %}
+
 {% set hasAdditionalMammograms = event.previousMammograms | length > 0 %}
 
 {% set lastMammogramHtml %}
@@ -109,11 +117,6 @@
 
   {% endif %}
 
-
-
-
-
-
 {% endset %}
 
 {% set riskLevel = participant | getCurrentRiskLevel | sentenceCase %}
@@ -121,6 +124,11 @@
 {% if riskLevel == "Family history" %}
   {% set riskLevel = "Family history: moderate risk" %}
 {% endif %}
+
+{% set testArray = [0] %}
+
+
+{{ testArray | log("testArray") }}
 
 {{ summaryList({
   rows: [
@@ -213,7 +221,7 @@
    },
    {
      key: {
-       text: "Address"
+       text: "Home address"
      },
      value: {
        html: address
@@ -221,7 +229,7 @@
      actions: {
         items: [
           {
-            href: "#",
+            href: participantId ~ "/personal-details/contact-details",
             text: "Change",
             visuallyHiddenText: "address"
           } if allowEdits
@@ -233,12 +241,12 @@
        text: "Phone"
      },
      value: {
-       text: participant.demographicInformation.phone | formatPhoneNumber
+       html: phoneHtml
      },
      actions: {
         items: [
           {
-            href: "#",
+            href: participantId ~ "/personal-details/contact-details",
             text: "Change",
             visuallyHiddenText: "phone"
           } if allowEdits
@@ -255,7 +263,7 @@
      actions: {
         items: [
           {
-            href: "#",
+            href: participantId ~ "/personal-details/contact-details",
             text: "Change",
             visuallyHiddenText: "email"
           } if allowEdits

--- a/app/views/_includes/summary-lists/participant.njk
+++ b/app/views/_includes/summary-lists/participant.njk
@@ -1,4 +1,5 @@
 {# /app/views/_includes/summary-lists/participant.njk #}
+{% set allowEdits = allowEdits | default(true) %}
 
 {% set dob %}
   {{ participant.demographicInformation.dateOfBirth | formatDate }}<br>
@@ -10,11 +11,9 @@
   {% if participant.demographicInformation.address.line2 %}
     {{ participant.demographicInformation.address.line2 }}<br>
   {% endif %}
-  {{ participant.demographicInformation.address.city }}<br>
+  {{ participant.demographicInformation.address.town }}<br>
   {{ participant.demographicInformation.address.postcode }}
 {% endset %}
-
-{% set allowEdits = allowEdits | default(true) %}
 
 {% set ethnicGroup = participant.demographicInformation.ethnicGroup %}
 {% set ethnicBackground = participant.demographicInformation.ethnicBackground %}

--- a/app/views/_includes/summary-lists/rows/address.njk
+++ b/app/views/_includes/summary-lists/rows/address.njk
@@ -20,6 +20,6 @@
        } if allowEdits
      ]
    }
-} %}
+} | handleSummaryListMissingInformation(showNotProvidedText) %}
 
 {{ appSummaryListRow(addressRow) }}

--- a/app/views/_includes/summary-lists/rows/address.njk
+++ b/app/views/_includes/summary-lists/rows/address.njk
@@ -1,10 +1,7 @@
+{% set addressLines = participant.demographicInformation.address | getObjectValues({removeEmpty: true }) %}
+
 {% set addressHtml %}
-  {{ participant.demographicInformation.address.line1 }}<br>
-  {% if participant.demographicInformation.address.line2 %}
-    {{ participant.demographicInformation.address.line2 }}<br>
-  {% endif %}
-  {{ participant.demographicInformation.address.town }}<br>
-  {{ participant.demographicInformation.address.postcode }}
+  {{ addressLines | join("<br>") | safe }}
 {% endset %}
 
 {% set addressRow = {
@@ -17,9 +14,9 @@
   actions: {
      items: [
        {
-         href: "../contact-details" | urlWithReferrer(currentUrl),
+        href: contextUrl ~ "/personal-details/contact-details" | urlWithReferrer(referrerChain),
          text: "Change",
-         visuallyHiddenText: "address"
+         visuallyHiddenText: "home address"
        } if allowEdits
      ]
    }

--- a/app/views/_includes/summary-lists/rows/address.njk
+++ b/app/views/_includes/summary-lists/rows/address.njk
@@ -9,7 +9,7 @@
 
 {% set addressRow = {
   key: {
-    text: "Addresses"
+    text: "Home address"
   },
   value: {
     html: addressHtml

--- a/app/views/_includes/summary-lists/rows/address.njk
+++ b/app/views/_includes/summary-lists/rows/address.njk
@@ -1,0 +1,28 @@
+{% set addressHtml %}
+  {{ participant.demographicInformation.address.line1 }}<br>
+  {% if participant.demographicInformation.address.line2 %}
+    {{ participant.demographicInformation.address.line2 }}<br>
+  {% endif %}
+  {{ participant.demographicInformation.address.town }}<br>
+  {{ participant.demographicInformation.address.postcode }}
+{% endset %}
+
+{% set addressRow = {
+  key: {
+    text: "Addresses"
+  },
+  value: {
+    html: addressHtml
+  },
+  actions: {
+     items: [
+       {
+         href: "../contact-details" | urlWithReferrer(currentUrl),
+         text: "Change",
+         visuallyHiddenText: "address"
+       } if allowEdits
+     ]
+   }
+} %}
+
+{{ appSummaryListRow(addressRow) }}

--- a/app/views/_includes/summary-lists/rows/email.njk
+++ b/app/views/_includes/summary-lists/rows/email.njk
@@ -5,7 +5,7 @@
     text: "Email"
   },
   value: {
-    html: participant.demographicInformation.email | trim
+    html: (participant.demographicInformation.email | trim) | safe
   },
   actions: {
      items: [
@@ -16,6 +16,6 @@
        } if allowEdits
      ]
    }
-} %}
+} | handleSummaryListMissingInformation(showNotProvidedText) %}
 
 {{ appSummaryListRow(emailRow) }}

--- a/app/views/_includes/summary-lists/rows/email.njk
+++ b/app/views/_includes/summary-lists/rows/email.njk
@@ -10,7 +10,7 @@
   actions: {
      items: [
        {
-         href: "../contact-details" | urlWithReferrer(currentPageUrl),
+         href: contextUrl ~ "/personal-details/contact-details" | urlWithReferrer(referrerChain or currentUrl),
          text: "Change",
          visuallyHiddenText: "email"
        } if allowEdits

--- a/app/views/_includes/summary-lists/rows/email.njk
+++ b/app/views/_includes/summary-lists/rows/email.njk
@@ -1,0 +1,21 @@
+
+
+{% set emailRow = {
+  key: {
+    text: "Email"
+  },
+  value: {
+    html: participant.demographicInformation.email | trim
+  },
+  actions: {
+     items: [
+       {
+         href: "../contact-details" | urlWithReferrer(currentPageUrl),
+         text: "Change",
+         visuallyHiddenText: "email"
+       } if allowEdits
+     ]
+   }
+} %}
+
+{{ appSummaryListRow(emailRow) }}

--- a/app/views/_includes/summary-lists/rows/phone-numbers.njk
+++ b/app/views/_includes/summary-lists/rows/phone-numbers.njk
@@ -6,7 +6,7 @@
 
 {% set phoneNumbersRow = {
   key: {
-    text: "Phone" if phoneNumbers | length == 1 else "Phone numbers"
+    text: "Phone" if phoneNumbers | length < 2 else "Phone numbers"
   },
   value: {
     html: phoneNumbersHtml | trim
@@ -16,10 +16,10 @@
       {
         href: contextUrl ~ "/personal-details/contact-details" | urlWithReferrer(referrerChain),
         text: "Change",
-        visuallyHiddenText: "phone number" if phoneNumbers | length == 1 else "phone numbers"
+        visuallyHiddenText: "phone number" if phoneNumbers | length < 2 else "phone numbers"
       } if allowEdits
      ]
   }
-} %}
+} | handleSummaryListMissingInformation(showNotProvidedText) %}
 
 {{ appSummaryListRow(phoneNumbersRow) }}

--- a/app/views/_includes/summary-lists/rows/phone-numbers.njk
+++ b/app/views/_includes/summary-lists/rows/phone-numbers.njk
@@ -1,27 +1,25 @@
+{% set phoneNumbers = [participant.demographicInformation.mobilePhone, participant.demographicInformation.homePhone] | removeEmpty %}
+
 {% set phoneNumbersHtml %}
-  {{ participant.demographicInformation.mobilePhone | formatPhoneNumber }}
-  {% if participant.demographicInformation.homePhone and participant.demographicInformation.mobilePhone %}
-    <br>
-  {% endif %}
-  {{ participant.demographicInformation.homePhone | formatPhoneNumber }}
+  {{ phoneNumbers | map("formatPhoneNumber") | join("<br>") | safe }}
 {% endset %}
 
 {% set phoneNumbersRow = {
   key: {
-    text: "Phone numbers"
+    text: "Phone" if phoneNumbers | length == 1 else "Phone numbers"
   },
   value: {
     html: phoneNumbersHtml | trim
   },
   actions: {
-     items: [
-       {
-         href: "../contact-details" | urlWithReferrer(currentUrl),
-         text: "Change",
-         visuallyHiddenText: "phone numbers"
-       } if allowEdits
+    items: [
+      {
+        href: contextUrl ~ "/personal-details/contact-details" | urlWithReferrer(referrerChain),
+        text: "Change",
+        visuallyHiddenText: "phone number" if phoneNumbers | length == 1 else "phone numbers"
+      } if allowEdits
      ]
-   }
+  }
 } %}
 
 {{ appSummaryListRow(phoneNumbersRow) }}

--- a/app/views/_includes/summary-lists/rows/phone-numbers.njk
+++ b/app/views/_includes/summary-lists/rows/phone-numbers.njk
@@ -1,0 +1,27 @@
+{% set phoneNumbersHtml %}
+  {{ participant.demographicInformation.mobilePhone | formatPhoneNumber }}
+  {% if participant.demographicInformation.homePhone and participant.demographicInformation.mobilePhone %}
+    <br>
+  {% endif %}
+  {{ participant.demographicInformation.homePhone | formatPhoneNumber }}
+{% endset %}
+
+{% set phoneNumbersRow = {
+  key: {
+    text: "Phone numbers"
+  },
+  value: {
+    html: phoneNumbersHtml | trim
+  },
+  actions: {
+     items: [
+       {
+         href: "../contact-details" | urlWithReferrer(currentUrl),
+         text: "Change",
+         visuallyHiddenText: "phone numbers"
+       } if allowEdits
+     ]
+   }
+} %}
+
+{{ appSummaryListRow(phoneNumbersRow) }}

--- a/app/views/_templates/layout.html
+++ b/app/views/_templates/layout.html
@@ -16,6 +16,10 @@
 {%- from '_components/secondary-navigation/macro.njk' import appSecondaryNavigation %}
 {%- from '_components/button-menu/macro.njk' import buttonMenu %}
 
+{%- from '_components/summary-list/macro.njk' import appSummaryListRow %}
+{%- from '_components/summary-list/macro.njk' import appSummaryList as summaryList %}
+
+
 <!-- Add your custom CSS or Sass in /app/assets/sass/main.scss -->
 {% block headCSS %}
   <link href="/css/main.css" rel="stylesheet">

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -78,6 +78,9 @@
   </li>
   <li>
     <a href="/participants">Participants</a>
+    <ul>
+      <li><a href="/participants/bc724e9f">Participant view</a></li>
+    </ul>
   </li>
   <li>
     <a href="/settings">Settings</a>

--- a/app/views/participants/personal-details/contact-details/confirm.html
+++ b/app/views/participants/personal-details/contact-details/confirm.html
@@ -11,7 +11,7 @@
 
 {# {% set formAction = "../" ~ participantId %} #}
 
-{% set formAction = participantUrl %}
+{% set formAction = participantUrl | getReturnUrl(referrerChain) %}
 
 
 {# {% set back = {
@@ -19,6 +19,8 @@
   text: "Back"
 } %}
  #}
+
+{% set allowEdits = true %}
 
 
 {% block pageContent %}

--- a/app/views/participants/personal-details/contact-details/confirm.html
+++ b/app/views/participants/personal-details/contact-details/confirm.html
@@ -11,14 +11,14 @@
 
 {# {% set formAction = "../" ~ participantId %} #}
 
-{% set formAction = participantUrl | getReturnUrl(referrerChain) %}
+{% set formAction = (participantUrl ~ "/save") | getReturnUrl(referrerChain) %}
 
 
-{# {% set back = {
-  href: "/events/" + clinicId,
-  text: "Back"
+{% set back = {
+  href: participantUrl,
+  text: "Back to participant"
 } %}
- #}
+
 
 {% set allowEdits = true %}
 
@@ -43,8 +43,12 @@
   {% include "summary-lists/demographic-information/contact-details.njk" %}
 
   {{ button({
-    text: "Confirm"
+    text: "Confirm changes"
   }) }}
+
+  <p>
+    <a href="{{participantUrl}}">Cancel and return to participant</a>
+  </p>
 
 
 {% endblock %}

--- a/app/views/participants/personal-details/contact-details/confirm.html
+++ b/app/views/participants/personal-details/contact-details/confirm.html
@@ -40,6 +40,7 @@
     {{ pageHeading }}
   </h1>
 
+  {% set showNotProvidedText = true %}
   {% include "summary-lists/demographic-information/contact-details.njk" %}
 
   {{ button({

--- a/app/views/participants/personal-details/contact-details/confirm.html
+++ b/app/views/participants/personal-details/contact-details/confirm.html
@@ -1,0 +1,49 @@
+
+{% extends 'layout-app.html' %}
+
+
+{# {% set pageHeading = participant | getShortName ~ "’s contact details" %} #}
+{% set pageHeading = "Confirm changes to contact details" %}
+
+
+
+{% set gridColumn = "nhsuk-grid-column-two-thirds" %}
+
+{# {% set formAction = "../" ~ participantId %} #}
+
+{% set formAction = participantUrl %}
+
+
+{# {% set back = {
+  href: "/events/" + clinicId,
+  text: "Back"
+} %}
+ #}
+
+
+{% block pageContent %}
+
+  {{ participant | log("participant") }}
+
+  {{ participantId | log("participantId") }}
+
+
+
+  {% set unit = data.breastScreeningUnits | findById(clinic.breastScreeningUnitId) %}
+
+  <h1 class="nhsuk-heading-l">
+    <span class="nhsuk-caption-m">
+      {{ participant | getFullName }}
+    </span>
+    {{ pageHeading }}
+  </h1>
+
+  {% include "summary-lists/demographic-information/contact-details.njk" %}
+
+  {{ button({
+    text: "Confirm"
+  }) }}
+
+
+{% endblock %}
+

--- a/app/views/participants/personal-details/contact-details/index.html
+++ b/app/views/participants/personal-details/contact-details/index.html
@@ -1,0 +1,49 @@
+
+{% extends 'layout-app.html' %}
+
+
+{# {% set pageHeading = participant | getShortName ~ "’s contact details" %} #}
+{% set pageHeading = "Contact details" %}
+
+
+
+{% set gridColumn = "nhsuk-grid-column-two-thirds" %}
+
+{# {% set formAction = "../" ~ participantId %} #}
+
+{% set formAction = "./contact-details/confirm" %}
+
+
+{# {% set back = {
+  href: "/events/" + clinicId,
+  text: "Back"
+} %}
+ #}
+
+
+{% block pageContent %}
+
+  {{ participant | log("participant") }}
+
+  {{ participantId | log("participantId") }}
+
+
+
+  {% set unit = data.breastScreeningUnits | findById(clinic.breastScreeningUnitId) %}
+
+  <h1 class="nhsuk-heading-l">
+    <span class="nhsuk-caption-m">
+      {{ participant | getFullName }}
+    </span>
+    {{ pageHeading }}
+  </h1>
+
+
+  {% include "forms/contact-details.njk" %}
+
+  {{ button({
+    text: "Continue"
+  }) }}
+
+{% endblock %}
+

--- a/app/views/participants/personal-details/contact-details/index.html
+++ b/app/views/participants/personal-details/contact-details/index.html
@@ -11,7 +11,7 @@
 
 {# {% set formAction = "../" ~ participantId %} #}
 
-{% set formAction = "./contact-details/confirm" %}
+{% set formAction = "./contact-details/confirm" | urlWithReferrer(referrerChain) %}
 
 
 {# {% set back = {

--- a/app/views/participants/personal-details/ethnicity/confirm.html
+++ b/app/views/participants/personal-details/ethnicity/confirm.html
@@ -1,0 +1,37 @@
+
+{% extends 'layout-app.html' %}
+
+
+{% set pageHeading = "Confirm changes to ethnicity" %}
+
+{% set gridColumn = "nhsuk-grid-column-two-thirds" %}
+
+{% set formAction = "./ethnicity-answer" %}
+
+
+{# {% set back = {
+  href: "/events/" + clinicId,
+  text: "Back"
+} %}
+ #}
+
+
+{% block pageContent %}
+
+
+  <h1 class="nhsuk-heading-l">
+    <span class="nhsuk-caption-m">
+      {{ participant | getFullName }}
+    </span>
+    {{ pageHeading }}
+  </h1>
+
+
+
+  {{ button({
+    text: "Save"
+  }) }}
+
+
+{% endblock %}
+

--- a/app/views/participants/show.html
+++ b/app/views/participants/show.html
@@ -18,12 +18,19 @@
   {{ participant | log("Participant") }}
   {{ event | log("Event") }}
 
+
+
   <h1 class="nhsuk-heading-l">
     <span class="nhsuk-caption-l">
       Participant record
     </span>
     {{ pageHeading | safe }}
   </h1>
+
+  {# For these summary cards we want to show the authoritative record, not the temp data.
+  The temp data only gets saved once going through a confirmation page #}
+  {% set tempParticipant = participant %}
+  {% set participant = originalParticipant %}
 
   {% set personalDetailsHtml %}
     {% include "summary-lists/participant.njk" %}

--- a/app/views/reading/confirm-abnormal.html
+++ b/app/views/reading/confirm-abnormal.html
@@ -67,7 +67,7 @@
           }
         }
       ]
-    } | showMissingInformationLink) }}
+    } | handleSummaryListMissingInformation) }}
 
     <h3>PACS annotations</h3>
 
@@ -153,7 +153,7 @@
           }
         }
       ]
-    } | showMissingInformationLink) }}
+    } | handleSummaryListMissingInformation) }}
   {% endset %}
 
 

--- a/app/views/reading/medical-information.html
+++ b/app/views/reading/medical-information.html
@@ -117,7 +117,7 @@
           }
         }
       ]
-    } | showMissingInformationLink) }}
+    } | handleSummaryListMissingInformation) }}
   {% endset %}
 
   {# {{ card({
@@ -149,7 +149,7 @@
           }
         }
       ]
-    } | showMissingInformationLink) }}
+    } | handleSummaryListMissingInformation) }}
   {% endset %}
 
   {# {{ card({

--- a/docs/views/template.html
+++ b/docs/views/template.html
@@ -27,8 +27,9 @@
 {%- from 'label/macro.njk' import label %}
 {%- from 'radios/macro.njk' import radios %}
 {%- from 'select/macro.njk' import select %}
-{%- from 'summary-list/macro.njk' import summaryList %}
-{%- from 'tabs/macro.njk' import tabs %} 
+{# Renamed summary list so we prefer our app one first #}
+{%- from 'summary-list/macro.njk' import summaryList as nativeSummaryList %}
+{%- from 'tabs/macro.njk' import tabs %}
 {%- from 'tag/macro.njk' import tag %}
 {%- from 'task-list/macro.njk' import taskList %}
 {%- from 'textarea/macro.njk' import textarea %}
@@ -72,7 +73,7 @@
     {% endblock %}
 
     {% block head %}{% endblock %}
-    
+
   </head>
 
   <body class="{{ bodyClasses }}">


### PR DESCRIPTION
## Description
Adds an edit page for contact details, accessed from the participant view.

This edit page combines address, phone, email address. These _could_ be separate pages, but I suspect you may sometimes want to update several, so for now have done as one.

Changes to these must be confirmed - there's now a confirmation page for changes. If not confirmed, the changes aren't saved.

![Screenshot of an edit form with fields for home address, two fields for phone numbers, one for email address](https://github.com/user-attachments/assets/ae0c0550-6601-4f64-b5ef-906638c7bb82)

![A confirmation page summarising the contact details with button to confirm or link to cancel](https://github.com/user-attachments/assets/de95bab7-31e6-4681-9668-be2a4bf003b2)

Note: confirmation page not applied everywhere (haven't had time - it should also occur on ethnicity page)