### PR TITLE
Fix for secondary navigation not showing correctly

### DIFF
--- a/app/views/_templates/layout-app.html
+++ b/app/views/_templates/layout-app.html
@@ -149,11 +149,13 @@
 </div>
 {% endif %}
 
-{% if pageNavigation %}
+{# You can't test if the block pageNavigation is truthy, so capture to a variable and then test the length #}
+{% set pageNavigationHtml %}{% block pageNavigation %}{% endblock pageNavigation %}{% endset %}
+
+{% if pageNavigationHtml | length > 0 %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
-      {% block pageNavigation %}
-      {% endblock pageNavigation %}
+      {{ pageNavigationHtml | safe }}
     </div>
   </div>
 {% endif %}

--- a/app/views/_templates/layout-reading.html
+++ b/app/views/_templates/layout-reading.html
@@ -174,7 +174,6 @@
     <div class="nhsuk-u-margin-bottom-4"></div>
     {% include "reading/secondary-navigation.njk" %}
 
-
   {% endif %}
 {% endblock pageNavigation %}
 


### PR DESCRIPTION
## Description
Image reading navigation / secondary nav isn't showing correctly. This is because in #118 I set `pageNavigation` to conditionally render only if the block was truthy - to avoid excess markup being generated on the page. I didn't realise that you [can't test whether a block is defined](https://github.com/mozilla/nunjucks/issues/135).

My solution is to capture the contents of the block then test the length of that.
