### PR TITLE
Image reading bugfixes

### DIFF
--- a/app/lib/utils/reading.js
+++ b/app/lib/utils/reading.js
@@ -1028,7 +1028,7 @@ const createReadingBatch = (data, options) => {
 
     // 3. Apply symptoms filter if specified
     if (filters.hasSymptoms) {
-      events = events.filter(event => event?.medicalInformation.symptoms?.length > 0)
+      events = events.filter(event => event?.medicalInformation?.symptoms && event?.medicalInformation.symptoms?.length > 0)
     }
   }
 

--- a/app/views/_templates/layout-app.html
+++ b/app/views/_templates/layout-app.html
@@ -149,17 +149,23 @@
 </div>
 {% endif %}
 
-
-{# This will output excess divs where pageNavigation is not set. I could not find a way to stop this. You can't test for truthiness of the block, nor can you capture the contents with set.
+{# Awkwardly test if pageNavigation is set. This is a workaround for Nunjucks
+   not having a way to check if a block is defined or not.
 
 See related issues:
 https://github.com/mozilla/nunjucks/issues/135
 https://github.com/mozilla/nunjucks/issues/164#issuecomment-3073581360 #}
-<div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-full">
-    {% block pageNavigation %}{% endblock pageNavigation %}
-  </div>
-</div>
+
+{% macro pageNavigationWrapper() %}
+  {% if caller() | length > 0 %}
+    <div class="nhsuk-grid-row">
+      <div class="nhsuk-grid-column-full">
+        {{ caller() }}
+      </div>
+    </div>
+  {% endif %}
+{% endmacro %}
+{% call pageNavigationWrapper() %}{% block pageNavigation %}{% endblock pageNavigation %}{% endcall %}
 
 {% if gridColumn != "none" %}
 <div class="nhsuk-grid-row">

--- a/app/views/_templates/layout-reading.html
+++ b/app/views/_templates/layout-reading.html
@@ -3,6 +3,7 @@
 
 {% set gridColumn = gridColumn or "nhsuk-grid-column-full" %}
 
+
 {% set isClinicContext = batch.clinicId %}
 {% set isBatchContext = not isClinicContext %}
 {# {% for clinic in clinics %}
@@ -168,6 +169,7 @@
 {% endif %}
 
 {% block pageNavigation %}
+
   {% if not hideSecondaryNavigation %}
     {% include "reading/opinion-ui.njk" %}
     {# <hr class="nhsuk-section-break nhsuk-section-break--m nhsuk-section-break--visible"> #}


### PR DESCRIPTION
## Description
Fixes a bug that was preventing custom batches being created of participants with symptoms.

Also improves on #120 with a method by @nickcolley for conditionally wrapping pageNavigation in markup.