### PR TITLE
Image reading annotation bugfixes

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -34,8 +34,8 @@ module.exports = {
     targetAttendancePercent: 100, // 100% of original capacity (not overbooking)
 
     // Date range for generating data
-    daysToGenerate: 8,
-    daysBeforeToday: 5,
+    daysToGenerate: 13,
+    daysBeforeToday: 11,
     historicPeriodCount: 1, // Number of historic periods to generate
 
     simulatedTime: '10:30', // 24h format

--- a/app/data/breast-screening-units.js
+++ b/app/data/breast-screening-units.js
@@ -69,15 +69,15 @@ module.exports = [
         ],
         registration: 'JA1 CP7',
         // Override BSU session patterns for this location
-        sessionPatterns: [
-          {
-            name: 'full_day',
-            type: 'single',
-            sessions: [
-              { startTime: '09:00', endTime: '17:00' },
-            ],
-          },
-        ],
+        // sessionPatterns: [
+        //   {
+        //     name: 'full_day',
+        //     type: 'single',
+        //     sessions: [
+        //       { startTime: '09:00', endTime: '17:00' },
+        //     ],
+        //   },
+        // ],
       },
       // {
       //   id: 'acxcdcnj', // Must be hardcoded so it matches generated data

--- a/app/filters/nunjucks.js
+++ b/app/filters/nunjucks.js
@@ -7,6 +7,80 @@ const log = (a, description = null) => {
   return `<script>${description || ''}console.log(${JSON.stringify(a, null, '\t')});</script>`
 }
 
+
+/**
+ * Safely join array elements with proper undefined/null handling
+ * @param {any} input - Array-like input to join
+ * @param {string} [delimiter=''] - String to use as delimiter between elements
+ * @param {string} [attribute] - Optional object property to extract before joining
+ * @param {Object} [options] - Additional options for join behavior
+ * @param {boolean} [options.filterEmpty=true] - Whether to filter out empty/null/undefined values
+ * @param {boolean} [options.toString=true] - Whether to convert values to strings before joining
+ * @returns {string} Joined string or empty string if invalid input
+ *
+ * @example
+ * join(['a', 'b', 'c'], ', ') // 'a, b, c'
+ * join([{name: 'John'}, {name: 'Jane'}], ', ', 'name') // 'John, Jane'
+ * join(['a', null, 'b'], ', ') // 'a, b' (filters nulls by default)
+ * join(null) // ''
+ * join(undefined) // ''
+ */
+const join = (input, delimiter = '', attribute = null, options = {}) => {
+  const {
+    filterEmpty = true,
+    toString = true
+  } = options
+
+  // Handle null, undefined, or non-array inputs
+  if (!input) {
+    return ''
+  }
+
+  // Convert to array if it's array-like but not an array
+  let array
+  if (Array.isArray(input)) {
+    array = input
+  } else if (input.length !== undefined) {
+    // Array-like object (NodeList, etc.)
+    array = Array.from(input)
+  } else {
+    // Single value, wrap in array
+    array = [input]
+  }
+
+  // Extract attribute values if specified
+  if (attribute) {
+    array = array.map(item => {
+      if (!item || typeof item !== 'object') {
+        return undefined
+      }
+      return item[attribute]
+    })
+  }
+
+  // Filter out empty values if requested
+  if (filterEmpty) {
+    array = array.filter(item => {
+      return item !== null &&
+             item !== undefined &&
+             item !== '' &&
+             (!toString || String(item).trim() !== '')
+    })
+  }
+
+  // Convert to strings if requested
+  if (toString) {
+    array = array.map(item => {
+      if (item === null || item === undefined) {
+        return ''
+      }
+      return String(item)
+    })
+  }
+
+  return array.join(delimiter)
+}
+
 /**
  * Get user name by user ID with format options
  * @param {string} userId - ID of the user
@@ -58,6 +132,7 @@ const getContext = function() {
 
 module.exports = {
   log,
+  join,
   getUsername,
   getContext,
 }

--- a/app/lib/generators/participant-generator.js
+++ b/app/lib/generators/participant-generator.js
@@ -146,102 +146,6 @@ const generateNHSNumber = () => {
   return `${baseNumber}${finalCheckDigit}`
 }
 
-// New medical history generators
-const generateMedicalHistorySurvey = () => {
-  // 50% chance of having completed the survey
-  if (Math.random() > 0.5) {
-    return null
-  }
-
-  return {
-    completedAt: faker.date.past({ years: 1 }).toISOString(),
-
-    // Non-cancerous procedures/diagnoses
-    nonCancerousProcedures: generateNonCancerousProcedures(),
-
-    // Current hormone therapy (if they had previous cancer)
-    onHormoneTherapy: Math.random() < 0.3, // 30% of those with cancer history
-
-    // Other medical history
-    otherMedicalHistory: Math.random() < 0.3
-      ? faker.helpers.arrayElements([
-        'Type 2 diabetes - diet controlled',
-        'High blood pressure - medication',
-        'Osteoarthritis',
-        'Previous shoulder surgery',
-        'Rheumatoid arthritis',
-      ], { min: 1, max: 2 })
-      : null,
-  }
-}
-
-const generateNonCancerousProcedures = () => {
-  const procedures = []
-
-  const possibleProcedures = {
-    benign_lump: {
-      probability: 0.15,
-      details: () => ({
-        dateDiscovered: faker.date.past({ years: 5 }).toISOString(),
-        position: faker.helpers.arrayElement(['Left breast', 'Right breast']),
-        wasRemoved: Math.random() < 0.7,
-        pathology: 'Fibroadenoma',
-      }),
-    },
-    cyst_aspiration: {
-      probability: 0.1,
-      details: () => ({
-        date: faker.date.past({ years: 3 }).toISOString(),
-        location: faker.helpers.arrayElement(['Left breast', 'Right breast']),
-        notes: 'Simple cyst, fluid aspirated',
-      }),
-    },
-    non_implant_augmentation: {
-      probability: 0.02,
-      details: () => ({
-        date: faker.date.past({ years: 5 }).toISOString(),
-        procedure: 'Fat transfer procedure',
-        hospital: 'General Hospital',
-      }),
-    },
-    breast_reduction: {
-      probability: 0.03,
-      details: () => ({
-        date: faker.date.past({ years: 5 }).toISOString(),
-        notes: 'Bilateral breast reduction',
-        hospital: 'City Hospital',
-      }),
-    },
-    previous_biopsy: {
-      probability: 0.08,
-      details: () => ({
-        date: faker.date.past({ years: 2 }).toISOString(),
-        result: 'Benign',
-        location: faker.helpers.arrayElement(['Left breast', 'Right breast']),
-      }),
-    },
-    skin_lesion: {
-      probability: 0.05,
-      details: () => ({
-        date: faker.date.past({ years: 3 }).toISOString(),
-        type: faker.helpers.arrayElement(['Seborrheic keratosis', 'Dermatofibroma']),
-        location: faker.helpers.arrayElement(['Left breast', 'Right breast']),
-      }),
-    },
-  }
-
-  Object.entries(possibleProcedures).forEach(([type, config]) => {
-    if (Math.random() < config.probability) {
-      procedures.push({
-        type,
-        ...config.details(),
-      })
-    }
-  })
-
-  return procedures
-}
-
 const generateParticipant = ({
   ethnicities,
   breastScreeningUnits,
@@ -286,17 +190,11 @@ const generateParticipant = ({
     },
     medicalInformation: {
       nhsNumber: generateNHSNumber(),
-      riskFactors: generateRiskFactors(),
-      familyHistory: generateFamilyHistory(),
-      previousCancerHistory: generatePreviousCancerHistory(),
-      medicalHistorySurvey: generateMedicalHistorySurvey(),
     },
     currentHealthInformation: {
       isPregnant: false,
       onHRT: Math.random() < 0.1,
-      hasBreastImplants: Math.random() < 0.05,
       recentBreastSymptoms: generateRecentSymptoms(),
-      medications: generateMedications(),
     },
   }
 
@@ -309,91 +207,6 @@ const generateParticipant = ({
   return _.merge({}, baseParticipant, participantOverrides)
 }
 
-// Modified family history generator to add more detail
-const generateFamilyHistory = () => {
-  if (Math.random() > 0.15) return null // 15% chance of family history
-
-  const affectedRelatives = faker.helpers.arrayElements(
-    [
-      { relation: 'mother', age: faker.number.int({ min: 35, max: 75 }) },
-      { relation: 'sister', age: faker.number.int({ min: 30, max: 70 }) },
-      { relation: 'daughter', age: faker.number.int({ min: 25, max: 45 }) },
-      { relation: 'grandmother', age: faker.number.int({ min: 45, max: 85 }) },
-      { relation: 'aunt', age: faker.number.int({ min: 40, max: 80 }) },
-    ],
-    { min: 1, max: 3 }
-  )
-
-  return {
-    hasFirstDegreeHistory: affectedRelatives.some(r =>
-      ['mother', 'sister', 'daughter'].includes(r.relation)
-    ),
-    affectedRelatives,
-    additionalDetails: Math.random() < 0.3
-      ? 'Multiple occurrences on maternal side'
-      : null,
-  }
-}
-
-const generateRiskFactors = () => {
-  const factors = []
-  const possibleFactors = {
-    family_history: 0.15,
-    dense_breast_tissue: 0.1,
-    previous_radiation_therapy: 0.05,
-    obesity: 0.2,
-    alcohol_consumption: 0.15,
-  }
-
-  Object.entries(possibleFactors).forEach(([factor, probability]) => {
-    if (Math.random() < probability) {
-      factors.push(factor)
-    }
-  })
-
-  return factors
-}
-
-// Modified previous cancer history to include more detail
-const generatePreviousCancerHistory = () => {
-  if (Math.random() > 0.02) return null // 2% chance of previous cancer
-
-  const treatments = faker.helpers.arrayElements(
-    [
-      { type: 'surgery', details: 'Wide local excision' },
-      { type: 'radiotherapy', details: '15 fractions' },
-      { type: 'chemotherapy', details: '6 cycles' },
-      { type: 'hormone_therapy', details: '5 years tamoxifen' },
-    ],
-    { min: 1, max: 3 }
-  )
-
-  return {
-    yearDiagnosed: faker.date.past({ years: 20 }).getFullYear(),
-    type: faker.helpers.arrayElement([
-      'ductal_carcinoma_in_situ',
-      'invasive_ductal_carcinoma',
-      'invasive_lobular_carcinoma',
-    ]),
-    position: faker.helpers.arrayElement([
-      'Left breast - upper outer quadrant',
-      'Right breast - upper outer quadrant',
-      'Left breast - lower inner quadrant',
-      'Right breast - lower inner quadrant',
-    ]),
-    treatments,
-    hospital: faker.helpers.arrayElement([
-      'City General Hospital',
-      'Royal County Hospital',
-      'Memorial Cancer Centre',
-      'University Teaching Hospital',
-    ]),
-    additionalNotes: Math.random() < 0.3
-      ? 'Regular follow-up completed'
-      : null,
-  }
-}
-
 const generateRecentSymptoms = () => {
   if (Math.random() > 0.1) return null // 10% chance of recent symptoms
 
@@ -404,17 +217,6 @@ const generateRecentSymptoms = () => {
     'skin_changes',
     'shape_change',
   ], { min: 1, max: 2 })
-}
-
-const generateMedications = () => {
-  if (Math.random() > 0.3) return [] // 30% chance of medications
-
-  return faker.helpers.arrayElements([
-    'hormone_replacement_therapy',
-    'blood_pressure_medication',
-    'diabetes_medication',
-    'cholesterol_medication',
-  ], { min: 1, max: 3 })
 }
 
 module.exports = {

--- a/app/views/reading/annotation.html
+++ b/app/views/reading/annotation.html
@@ -1,19 +1,22 @@
-{# /app/views/events/reading/awaiting-annotations.html #}
+{# /app/views/reading/annotation.html #}
 
 {% extends 'layout-reading.html' %}
 
-{% set pageHeading = "Add " + query.side + " breast abnormality" %}
+{% set annotation = data.imageReadingTemp.annotationTemp %}
+
+{% set side = annotation.side %}
+{% set pageHeading = ("Add" if not annotation.id else "Edit") + " " + side + " breast abnormality" %}
 
 {% set gridColumn = "none" %}
 
-{% set formAction = './result-abnormal' %}
+{% set formAction = './annotation/save' %}
 
 {% set hideSecondaryNavigation = true %}
 
 
 {% block pageContent %}
 
-  {{ progress.skippedEvents | log("progress") }}
+{{ annotation | log("This annotation" )}}
 
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
@@ -31,7 +34,7 @@
 
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
-      {% if query.side == 'right' %}
+      {% if side == 'right' %}
         {% set views = ['RMLO', 'RCC'] %}
       {% else %}
         {% set views = ['LMLO', 'LCC'] %}
@@ -52,6 +55,8 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
       {{ input({
+        name: "imageReadingTemp[annotationTemp][location]",
+        value: data.imageReadingTemp.annotationTemp.location,
         label: {
           text: "Location",
           classes: "nhsuk-label--s"
@@ -59,19 +64,19 @@
         hint: {
           text: "For example, upper right quadrant"
         },
-        id: "other text",
-        name: "other text"
+        classes: "nhsuk-u-width-two-thirds"
       }) }}
 
       {% set checkboxItems = [] %}
 
       {% macro makeCheckboxConditionalItem(params) %}
         {{ input({
+          name: "imageReadingTemp[annotationTemp][" + params.value + "Details]",
+          value: data.imageReadingTemp.annotationTemp[params.value + "Details"],
           label: {
             text: "Provide details"
           },
-          id: params.value + "Details",
-          name: params.value + "Details"
+          classes: "nhsuk-u-width-two-thirds"
         }) }}
       {% endmacro %}
 
@@ -87,7 +92,7 @@
 
       {% for abnormality in abnormalityList %}
         {% set checkboxItems = checkboxItems | push({
-          value: abnormality | camelCase,
+          value: abnormality,
           text: abnormality,
           conditional: {
             html: makeCheckboxConditionalItem({value: abnormality | camelCase})
@@ -97,16 +102,17 @@
 
       {% set otherTextInputHtml %}
         {{ input({
+          name: "imageReadingTemp[annotationTemp][otherDetails]",
+          value: data.imageReadingTemp.annotationTemp.otherDetails,
           label: {
             text: "Provide details"
           },
-          id: "other text",
-          name: "other text"
+          classes: "nhsuk-u-width-two-thirds"
         }) }}
       {% endset %}
 
       {% set checkboxItems = checkboxItems | push({
-        value: "other",
+        value: "Other",
         text: "Other",
         conditional: {
           html: otherTextInputHtml
@@ -114,8 +120,8 @@
       }) %}
 
       {{ checkboxes({
-        idPrefix: "example",
-        name: "example",
+        name: "imageReadingTemp[annotationTemp][abnormalityType]",
+        values: data.imageReadingTemp.annotationTemp.abnormalityType,
         fieldset: {
           legend: {
             text: "Select abnormality type",
@@ -127,63 +133,79 @@
       }) }}
 
       {{ select({
-        id: "select-1",
-        name: "select-1",
+        name: "imageReadingTemp[annotationTemp][levelOfConcern]",
+        value: data.imageReadingTemp.annotationTemp.levelOfConcern,
         label: {
           text: "Level of concern",
           classes: "nhsuk-label--s"
         },
         items: [
           {
-            value: 1,
+            value: "",
             text: "Please select",
             disabled: true,
-            selected: true
+            selected: true if not annotationTemp.levelOfConcern
           },
           {
-            value: 1,
+            value: "1",
             text: "1 - Normal"
           },
           {
-            value: 2,
+            value: "2",
             text: "2 - Benign"
           },
           {
-            value: 3,
+            value: "3",
             text: "3 - Probably benign"
           },
           {
-            value: 4,
+            value: "4",
             text: "4 - Probably cancerous"
           },
           {
-            value: 5,
+            value: "5",
             text: "5 - Likely cancerous"
           }
         ]
       }) }}
 
-      {# {{ textarea({
-        label: {
-          text: "Provide additional comments",
-          classes: "nhsuk-label--s"
-        },
-        id: "comment",
-        name: "comment"
-      }) }} #}
-
-      <div class="nhsuk-form-group nhsuk-u-margin-top-7">
+      <div class="nhsuk-button-group nhsuk-u-margin-top-7">
         {{ button({
           text: "Save and close",
-          href: "./recall-for-assessment-details?[imageReadingTemp][" + query.side + "][annotatedCount]=" + (data.imageReadingTemp[query.side].annotatedCount | int | default(0) + 1)
+          attributes: {
+            name: "action",
+            value: "save"
+          }
         }) }}
 
         {{ button({
           text: "Save and add another abnormality",
           classes: "nhsuk-button--secondary",
-          href: "./annotation?[imageReadingTemp][" + query.side + "][annotatedCount]=" + (data.imageReadingTemp[query.side].annotatedCount | int | default(0) + 2)
+          attributes: {
+            name: "action",
+            value: "save-and-add"
+          }
+        }) }}
+
+
+
+        {# Hidden field to preserve the side #}
+        {{ appHiddenInput({
+          name: "side",
+          value: side
         }) }}
       </div>
+      {# Only show link if this is a previously saved symptom #}
+      {% if annotation.id %}
+        {% set deleteHref %}
+          ./annotation/delete/{{ annotation.id }}
+        {% endset %}
+        <p class="nhsuk-u-margin-top-4">
+          <a href="{{ deleteHref }}" class="nhsuk-link app-link--warning">
+            Delete this annotation
+          </a>
+        </p>
+      {% endif %}
     </div>
   </div>
 

--- a/app/views/reading/annotation.html
+++ b/app/views/reading/annotation.html
@@ -187,13 +187,6 @@
           }
         }) }}
 
-
-
-        {# Hidden field to preserve the side #}
-        {{ appHiddenInput({
-          name: "side",
-          value: side
-        }) }}
       </div>
       {# Only show link if this is a previously saved symptom #}
       {% if annotation.id %}
@@ -206,6 +199,19 @@
           </a>
         </p>
       {% endif %}
+
+      {# Hidden field to preserve the side #}
+      {{ appHiddenInput({
+        name: "side",
+        value: side
+      }) }}
+
+      {# Used by js to store marker positions #}
+      {{ appHiddenInput({
+        name: "imageReadingTemp[annotationTemp][markerPositions]",
+        value: (annotation.markerPositions | dump) if annotation.markerPositions,
+        id: "markerPositions"
+      }) }}
     </div>
   </div>
 
@@ -214,17 +220,25 @@
 
 {% block pageScripts %}
   <script type="module">
-// Mammogram annotation functionality with improved dragging
+// Mammogram annotation functionality with coordinate saving
 document.addEventListener('DOMContentLoaded', () => {
   const mammogramImages = document.querySelectorAll('.app-mammogram-image')
+  const markerPositionsInput = document.getElementById('markerPositions')
 
   // Keep track of markers for each image
   const markers = {}
+
+  // Get existing marker positions if editing
+  const existingPositions = getExistingMarkerPositions()
 
   // Track dragging state
   let activeMarker = null
   let isDragging = false
   let activeContainer = null
+
+  // Track loaded images
+  let imagesLoaded = 0
+  const totalImages = mammogramImages.length
 
   // Set up each mammogram image
   mammogramImages.forEach((image, index) => {
@@ -241,6 +255,13 @@ document.addEventListener('DOMContentLoaded', () => {
     // Apply custom cursor
     image.style.cursor = 'crosshair'
 
+    // Wait for image to load before restoring markers
+    if (image.complete) {
+      handleImageLoaded()
+    } else {
+      image.addEventListener('load', () => handleImageLoaded())
+    }
+
     // Add click handler to place/move marker
     image.addEventListener('click', (event) => {
       // Only place marker if we're not currently dragging
@@ -249,6 +270,61 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     })
   })
+
+  // Handle when an image is loaded
+  function handleImageLoaded() {
+    imagesLoaded++
+
+    // When all images are loaded, restore all existing markers
+    if (imagesLoaded === totalImages && existingPositions) {
+      // Small delay to ensure layout is settled
+      setTimeout(() => {
+        restoreAllMarkers()
+      }, 50)
+    }
+  }
+
+  // Restore all markers that have saved positions
+  function restoreAllMarkers() {
+    Object.entries(existingPositions).forEach(([imageId, position]) => {
+      const image = document.querySelector(`[data-image-id="${imageId}"]`)
+      if (image) {
+        restoreMarker(image, imageId, position)
+      }
+    })
+  }
+
+  // Get existing marker positions from hidden field
+  function getExistingMarkerPositions() {
+    try {
+      const value = markerPositionsInput?.value
+      return value ? JSON.parse(value) : null
+    } catch (e) {
+      return null
+    }
+  }
+
+  // Restore a marker at saved position
+  function restoreMarker(image, imageId, position) {
+    const container = image.parentElement
+
+    // Use the actual container dimensions at restore time
+    const containerRect = container.getBoundingClientRect()
+
+    // Convert percentages back to pixel positions
+    const x = (position.x / 100) * containerRect.width
+    const y = (position.y / 100) * containerRect.height
+
+    console.log(`Restoring marker for ${imageId}:`, {
+      position,
+      containerWidth: containerRect.width,
+      containerHeight: containerRect.height,
+      calculatedX: x,
+      calculatedY: y
+    })
+
+    createMarkerElement(container, imageId, x, y)
+  }
 
   // Place or move a marker
   function placeMarker(event, image, imageId) {
@@ -265,68 +341,106 @@ document.addEventListener('DOMContentLoaded', () => {
       marker.style.top = `${y}px`
     } else {
       // Create new marker
-      const marker = document.createElement('div')
-      marker.className = 'app-mammogram-marker'
-      marker.dataset.imageId = imageId
-      marker.style.position = 'absolute'
-      marker.style.left = `${x}px`
-      marker.style.top = `${y}px`
-      marker.style.width = '30px'
-      marker.style.height = '30px'
-      marker.style.borderRadius = '50%'
-      marker.style.border = '3px solid #d5281b'
-      marker.style.backgroundColor = 'rgba(213, 40, 27, 0.4)'
-      marker.style.transform = 'translate(-50%, -50%)'
-      marker.style.boxShadow = '0 0 0 2px rgba(255, 255, 255, 0.7), 0 0 8px rgba(0, 0, 0, 0.5)'
-      marker.style.zIndex = '10'
-      marker.style.cursor = 'grab'
-      marker.style.pointerEvents = 'auto' // Make it interactive for dragging
+      createMarkerElement(container, imageId, x, y)
+    }
 
-      // Add crosshair
-      const horizontal = document.createElement('div')
-      horizontal.style.position = 'absolute'
-      horizontal.style.left = '0'
-      horizontal.style.top = '50%'
-      horizontal.style.width = '100%'
-      horizontal.style.height = '2px'
-      horizontal.style.backgroundColor = '#d5281b'
-      horizontal.style.transform = 'translateY(-50%)'
+    // Save coordinates to hidden field
+    saveMarkerPositions()
+  }
 
-      const vertical = document.createElement('div')
-      vertical.style.position = 'absolute'
-      vertical.style.left = '50%'
-      vertical.style.top = '0'
-      vertical.style.width = '2px'
-      vertical.style.height = '100%'
-      vertical.style.backgroundColor = '#d5281b'
-      vertical.style.transform = 'translateX(-50%)'
+  // Create marker element
+  function createMarkerElement(container, imageId, x, y) {
+    const marker = document.createElement('div')
+    marker.className = 'app-mammogram-marker'
+    marker.dataset.imageId = imageId
+    marker.style.position = 'absolute'
+    marker.style.left = `${x}px`
+    marker.style.top = `${y}px`
+    marker.style.width = '30px'
+    marker.style.height = '30px'
+    marker.style.borderRadius = '50%'
+    marker.style.border = '3px solid #d5281b'
+    marker.style.backgroundColor = 'rgba(213, 40, 27, 0.4)'
+    marker.style.transform = 'translate(-50%, -50%)'
+    marker.style.boxShadow = '0 0 0 2px rgba(255, 255, 255, 0.7), 0 0 8px rgba(0, 0, 0, 0.5)'
+    marker.style.zIndex = '10'
+    marker.style.cursor = 'grab'
+    marker.style.pointerEvents = 'auto'
 
-      marker.appendChild(horizontal)
-      marker.appendChild(vertical)
+    // Add crosshair
+    const horizontal = document.createElement('div')
+    horizontal.style.position = 'absolute'
+    horizontal.style.left = '0'
+    horizontal.style.top = '50%'
+    horizontal.style.width = '100%'
+    horizontal.style.height = '2px'
+    horizontal.style.backgroundColor = '#d5281b'
+    horizontal.style.transform = 'translateY(-50%)'
 
-      // Add marker to container
-      container.appendChild(marker)
-      markers[imageId] = marker
+    const vertical = document.createElement('div')
+    vertical.style.position = 'absolute'
+    vertical.style.left = '50%'
+    vertical.style.top = '0'
+    vertical.style.width = '2px'
+    vertical.style.height = '100%'
+    vertical.style.backgroundColor = '#d5281b'
+    vertical.style.transform = 'translateX(-50%)'
 
-      // Add mousedown event for drag start
-      marker.addEventListener('mousedown', startDragging)
+    marker.appendChild(horizontal)
+    marker.appendChild(vertical)
+
+    // Add marker to container
+    container.appendChild(marker)
+    markers[imageId] = marker
+
+    // Add mousedown event for drag start
+    marker.addEventListener('mousedown', startDragging)
+  }
+
+  // Save marker positions as percentages
+  function saveMarkerPositions() {
+    const positions = {}
+
+    Object.entries(markers).forEach(([imageId, marker]) => {
+      const container = marker.parentElement
+      const rect = container.getBoundingClientRect()
+
+      // Get current marker position
+      const markerX = parseFloat(marker.style.left)
+      const markerY = parseFloat(marker.style.top)
+
+      // Convert to percentages
+      const percentX = (markerX / rect.width) * 100
+      const percentY = (markerY / rect.height) * 100
+
+      positions[imageId] = {
+        x: percentX,
+        y: percentY
+      }
+
+      console.log(`Saving marker for ${imageId}:`, {
+        pixelX: markerX,
+        pixelY: markerY,
+        containerWidth: rect.width,
+        containerHeight: rect.height,
+        percentX,
+        percentY
+      })
+    })
+
+    // Update hidden field
+    if (markerPositionsInput) {
+      markerPositionsInput.value = JSON.stringify(positions)
     }
   }
 
   // Start dragging a marker
   function startDragging(event) {
-    // Prevent default to avoid text selection during drag
     event.preventDefault()
-
-    // Get the marker and its container
     activeMarker = event.currentTarget
     activeContainer = activeMarker.parentElement
     isDragging = true
-
-    // Change cursor to indicate dragging
     activeMarker.style.cursor = 'grabbing'
-
-    // Add a class for visual feedback
     activeMarker.classList.add('dragging')
   }
 
@@ -335,30 +449,28 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!isDragging || !activeMarker || !activeContainer) return
 
     const rect = activeContainer.getBoundingClientRect()
-
-    // Calculate position relative to the container
     let x = event.clientX - rect.left
     let y = event.clientY - rect.top
 
     // Constrain to container bounds
-    x = Math.max(0, Math.min(rect.width, x))
-    y = Math.max(0, Math.min(rect.height, y))
+    x = Math.max(15, Math.min(rect.width - 15, x)) // Keep marker center within bounds
+    y = Math.max(15, Math.min(rect.height - 15, y))
 
     // Update marker position
     activeMarker.style.left = `${x}px`
     activeMarker.style.top = `${y}px`
+
+    // Save coordinates during drag
+    saveMarkerPositions()
   })
 
   // End dragging
   document.addEventListener('mouseup', () => {
     if (activeMarker) {
-      // Reset cursor
       activeMarker.style.cursor = 'grab'
-      // Remove dragging class
       activeMarker.classList.remove('dragging')
     }
 
-    // Reset dragging state
     isDragging = false
     activeMarker = null
     activeContainer = null

--- a/app/views/reading/annotation.html
+++ b/app/views/reading/annotation.html
@@ -16,7 +16,7 @@
 
 {% block pageContent %}
 
-{{ annotation | log("This annotation" )}}
+  {{ annotation | log("This annotation" )}}
 
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
@@ -28,26 +28,47 @@
         {{ pageHeading }}
       </h1>
 
-      <h2 class="nhsuk-heading-m">Mark the location</h2>
     </div>
   </div>
 
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
-      {% if side == 'right' %}
-        {% set views = ['RMLO', 'RCC'] %}
-      {% else %}
-        {% set views = ['LMLO', 'LCC'] %}
-      {% endif %}
+      {% set mammogramError = flash.error | find('name', 'markerPositions') %}
 
-      <div class="app-image-two-up nhsuk-u-margin-bottom-6">
-        {% for view in views %}
-         <div class="app-mammogram-container">
-           <img draggable="false" class="nhsuk-image__img app-mammogram-image" src="/images/mammogram-diagrams/{{ view | lower }}.png" alt="">
-         </div>
+      <div class="nhsuk-form-group{{ ' nhsuk-form-group--error' if mammogramError }}">
+        <h2 class="nhsuk-label nhsuk-label--m" id="mammogram-section">Mark the location</h2>
 
-        {% endfor %}
+        {% if mammogramError %}
+          <span class="nhsuk-error-message" id="mammogram-section-error">
+            <span class="nhsuk-u-visually-hidden">Error:</span> {{ mammogramError.text }}
+          </span>
+        {% endif %}
+
+        {{ mammogramError | log("Mammogram error") }}
+        {% if side == 'right' %}
+          {% set views = ['RMLO', 'RCC'] %}
+        {% else %}
+          {% set views = ['LMLO', 'LCC'] %}
+        {% endif %}
+
+        <div class="app-image-two-up nhsuk-u-margin-bottom-6">
+          {% for view in views %}
+          <div class="app-mammogram-container">
+            <img draggable="false" class="nhsuk-image__img app-mammogram-image" src="/images/mammogram-diagrams/{{ view | lower }}.png" alt="">
+          </div>
+
+          {% endfor %}
+        </div>
+
+
       </div>
+
+
+
+
+
+
+
 
     </div>
   </div>

--- a/app/views/reading/annotation.html
+++ b/app/views/reading/annotation.html
@@ -206,7 +206,7 @@
         }) }}
 
         {{ button({
-          text: "Save and add another abnormality",
+          text: "Save and add another " + side + " breast abnormality",
           classes: "nhsuk-button--secondary",
           attributes: {
             name: "action",

--- a/app/views/reading/annotation.html
+++ b/app/views/reading/annotation.html
@@ -55,6 +55,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
       {{ input({
+        id: "location",
         name: "imageReadingTemp[annotationTemp][location]",
         value: data.imageReadingTemp.annotationTemp.location,
         label: {
@@ -65,7 +66,7 @@
           text: "For example, upper right quadrant"
         },
         classes: "nhsuk-u-width-two-thirds"
-      }) }}
+      } | populateErrors) }}
 
       {% set checkboxItems = [] %}
 
@@ -73,11 +74,12 @@
         {{ input({
           name: "imageReadingTemp[annotationTemp][" + params.value + "Details]",
           value: data.imageReadingTemp.annotationTemp[params.value + "Details"],
+          id: params.value + "Details",
           label: {
             text: "Provide details"
           },
           classes: "nhsuk-u-width-two-thirds"
-        }) }}
+        } | populateErrors) }}
       {% endmacro %}
 
       {% set abnormalityList = [
@@ -104,11 +106,12 @@
         {{ input({
           name: "imageReadingTemp[annotationTemp][otherDetails]",
           value: data.imageReadingTemp.annotationTemp.otherDetails,
+          id: "otherDetails",
           label: {
             text: "Provide details"
           },
           classes: "nhsuk-u-width-two-thirds"
-        }) }}
+        } | populateErrors) }}
       {% endset %}
 
       {% set checkboxItems = checkboxItems | push({
@@ -120,6 +123,8 @@
       }) %}
 
       {{ checkboxes({
+        id: "abnormalityType",
+        idPrefix: "abnormalityType",
         name: "imageReadingTemp[annotationTemp][abnormalityType]",
         values: data.imageReadingTemp.annotationTemp.abnormalityType,
         fieldset: {
@@ -130,9 +135,10 @@
           }
         },
         items: checkboxItems
-      }) }}
+      } | populateErrors) }}
 
       {{ select({
+        id: "levelOfConcern",
         name: "imageReadingTemp[annotationTemp][levelOfConcern]",
         value: data.imageReadingTemp.annotationTemp.levelOfConcern,
         label: {
@@ -144,7 +150,7 @@
             value: "",
             text: "Please select",
             disabled: true,
-            selected: true if not annotationTemp.levelOfConcern
+            selected: true if not data.imageReadingTemp.annotationTemp.levelOfConcern
           },
           {
             value: "1",
@@ -167,7 +173,7 @@
             text: "5 - Likely cancerous"
           }
         ]
-      }) }}
+      } | populateErrors) }}
 
       <div class="nhsuk-button-group nhsuk-u-margin-top-7">
         {{ button({

--- a/app/views/reading/index.html
+++ b/app/views/reading/index.html
@@ -18,9 +18,9 @@
 {# Remove awaiting priors #}
 {% set allReadsEvents = allReadsEventsWithAwaitingPriors | where("hasRequestedImages", "false") %}
 
-{% set recentEvents = allReadsEvents | filterEventsByDayRange(0, data.config.priorityThreshold) %}
+{% set recentEvents = allReadsEvents | filterEventsByDayRange(0, data.config.reading.priorityThreshold) %}
 
-{% set priorityEvents = allReadsEvents | filterEventsByDayRange(data.config.priorityThreshold, 10) %}
+{% set priorityEvents = allReadsEvents | filterEventsByDayRange(data.config.reading.priorityThreshold, data.config.reading.urgentThreshold - 1) %}
 {% set urgentEvents = allReadsEvents | filterEventsByDayRange(data.config.reading.urgentThreshold) %}
 
 

--- a/app/views/reading/recall-for-assessment-details.html
+++ b/app/views/reading/recall-for-assessment-details.html
@@ -1,4 +1,4 @@
-{# /app/views/events/reading/recall-for-assessment-reasons.html #}
+{# /app/views/reading/recall-for-assessment-details.html #}
 
 {% extends 'layout-reading.html' %}
 
@@ -18,19 +18,17 @@
 
     {% set abnormalDetailsHtml %}
 
-
-
       {{ button({
-        text: "Mark an abnormality" if not (data.imageReadingTemp[params.side].annotatedCount | int > 0) else "Mark another abnormality",
+        text: "Mark an abnormality" if not ((data.imageReadingTemp[params.side].annotations | default([])) | length > 0) else "Mark another abnormality",
         classes: "nhsuk-button--secondary",
-        href: "./annotation?side=" + params.side + "&[imageReadingTemp][" + params.side + "][breastAssessment]=abnormal"
+        href: "./annotation/add?side=" + params.side + "&[imageReadingTemp][" + params.side + "][breastAssessment]=abnormal"
       }) }}
 
     {% endset %}
 
-    {{ data.imageReadingTemp | log("Image reading") }}
-
     {{ radios({
+      name: "imageReadingTemp[" + params.side + "][breastAssessment]",
+      value: data.imageReadingTemp[params.side].breastAssessment,
       fieldset: {
         legend: {
           text: "What is your opinion of the " + params.side + " breast?",
@@ -55,75 +53,68 @@
           }
         }
       ] | removeEmpty
-    } | decorateAttributes(data, "imageReadingTemp." + params.side + ".breastAssessment" )) }}
+    }) }}
 
     {{ input({
+      name: "imageReadingTemp[" + params.side + "][comment]",
+      value: data.imageReadingTemp[params.side].comment,
       label: {
         text: Side + " breast comment (optional)",
         classes: "nhsuk-label--s"
       },
-      _classes: "nhsuk-u-width-two-thirds"
-    } | decorateAttributes(data, "imageReadingTemp." + params.side + ".comment")) }}
+      classes: "nhsuk-u-width-two-thirds"
+    }) }}
 
-    {% if data.imageReadingTemp[params.side].annotatedCount | int %}
+    {% if (data.imageReadingTemp[params.side].annotations | default([])) | length > 0 %}
 
       <h3>Abnormalities</h3>
 
+      {% set summaryItems = [] %}
+
+      {% for annotation in data.imageReadingTemp[params.side].annotations %}
 
         {% set annotationValueHtml -%}
-          {% if params.side == 'right' %}
-            Location: upper right quadrant
-            Level of concern: 4 - Probably cancerous
-          {% else %}
-            Location: Lower left quadrant
-            Level of concern: 3 - Probably benign
+          {% if annotation.location %}
+            Location: {{ annotation.location }}<br>
           {% endif %}
+          Level of concern: {{ annotation.levelOfConcern }} -
+          {%- if annotation.levelOfConcern == "1" %} normal
+          {%- elif annotation.levelOfConcern == "2" %} benign
+          {%- elif annotation.levelOfConcern == "3" %} probably benign
+          {%- elif annotation.levelOfConcern == "4" %} probably cancerous
+          {%- elif annotation.levelOfConcern == "5" %} likely cancerous
+          {%- endif -%}
         {%- endset %}
 
-        {% set summaryItems = [] %}
+        {% set abnormalityTypeText = annotation.abnormalityType | join("<br>") | safe %}
 
-        {% for item in range(0, data.imageReadingTemp[params.side].annotatedCount | int) %}
+        {# {% if annotation.abnormalityType == "Other" and annotation.otherDetails %}
+          {% set abnormalityTypeText = annotation.otherDetails %}
+        {% endif %} #}
 
-          {% set abnormalityList = [
-            "Mass well-defined",
-            "Mass ill-defined",
-            "Architectural distortion",
-            "Asymetric density",
-            "Microcalcification outside a mass",
-            "Clinical abnormality",
-            "Lymph node abnormality"
-          ] %}
-
-          {% set abnormalityType = abnormalityList | randomItem(params.side ~ loop.index0) %}
-
-          {% set summaryItems = summaryItems | push(
-            {
-              key: {
-                text: abnormalityType
-              },
-              value: {
-                html: annotationValueHtml | trim | nl2br
-              },
-              actions: {
-                items: [
-                  {
-                    href: "#",
-                    text: "Change",
-                    visuallyHiddenText: "name"
-                  }
-                ]
+        {% set summaryItems = summaryItems | push({
+          key: {
+            text: abnormalityTypeText
+          },
+          value: {
+            html: annotationValueHtml | trim
+          },
+          actions: {
+            items: [
+              {
+                href: "./annotation/edit/" + annotation.id,
+                text: "Change",
+                visuallyHiddenText: abnormalityTypeText
               }
-            }
-          ) %}
-        {% endfor %}
+            ]
+          }
+        }) %}
+      {% endfor %}
 
-        {{ summaryItems | log("Summary items") }}
-
-        {{ summaryList({
-          rows: summaryItems
-        }) }}
-      {% endif %}
-
+      {{ summaryList({
+        rows: summaryItems
+      }) }}
+    {% endif %}
 
   {% endset %}
 
@@ -161,14 +152,13 @@
 
   <div class="nhsuk-grid-row">
 
-
-      {% for breastSide in ["right", "left"] %}
-      <div class="nhsuk-grid-column-one-half">
-        {{ breastDetails({
-          side: breastSide
-        }) }}
-      </div>
-      {% endfor %}
+    {% for breastSide in ["right", "left"] %}
+    <div class="nhsuk-grid-column-one-half">
+      {{ breastDetails({
+        side: breastSide
+      }) }}
+    </div>
+    {% endfor %}
 
   </div>
 
@@ -183,5 +173,3 @@
   </div>
 
 {% endblock %}
-
-

--- a/app/views/reading/recall-for-assessment-details.html
+++ b/app/views/reading/recall-for-assessment-details.html
@@ -153,11 +153,11 @@
   <div class="nhsuk-grid-row">
 
     {% for breastSide in ["right", "left"] %}
-    <div class="nhsuk-grid-column-one-half">
-      {{ breastDetails({
-        side: breastSide
-      }) }}
-    </div>
+      <div class="nhsuk-grid-column-one-half">
+        {{ breastDetails({
+          side: breastSide
+        }) }}
+      </div>
     {% endfor %}
 
   </div>


### PR DESCRIPTION
## Description
Image reading annotations didn't previously save data. They faked it and showed some simulated annotations. This was confusing and rather buggy.

This updates the flows to actually save annotations and restore them when you go to edit. I've also added validation to the page as the summary lists look rather broken if you don't fill in the forms.

Also increases the number of historical clinics to generate so we'll have some near and over target breach.


