### PR TITLE
Explicitly leave appointment if navigating via header link

### DIFF
--- a/app/views/_templates/layout-app.html
+++ b/app/views/_templates/layout-app.html
@@ -17,9 +17,13 @@
 {% block header %}
 
   {% set useMinimalNav = useMinimalNav | default(false) %}
+  {% set rootHref = "/" %}
 
   {% if event and event | isAppointmentWorkflow %}
     {% set useMinimalNav = true %}
+
+    {# Explicitly leave appointment if navigating away #}
+    {% set rootHref = eventUrl ~ "/leave" | urlWithReferrer("/") %}
   {% endif %}
 
   {{ header({
@@ -38,7 +42,7 @@
     },
     service: {
       text: serviceName,
-      href: "/"
+      href: rootHref
     },
     navigation: {
       items:


### PR DESCRIPTION
The prototype tracks state when you are running an appointment to know whether to show the workflow header or not. This means if we use the hidden service name link to navigate away, we need to explicitly leave the appointment. If we don't do this, the workflow header will start appearing on pages it shouldn't.