### PR TITLE
Add other medical information section and page

### DIFF
--- a/app/views/_includes/summary-lists/medical-information/other-relevant-information.njk
+++ b/app/views/_includes/summary-lists/medical-information/other-relevant-information.njk
@@ -122,7 +122,7 @@
         text: "Other medical information"
       },
       value: {
-        html: ""
+        html: data.event.medicalInformation.otherMedicalInformation
       },
       actions: {
         items: [

--- a/app/views/_includes/summary-lists/medical-information/other-relevant-information.njk
+++ b/app/views/_includes/summary-lists/medical-information/other-relevant-information.njk
@@ -119,7 +119,7 @@
     },
     {
       key: {
-        text: "Mammographer notes"
+        text: "Other medical information"
       },
       value: {
         html: ""
@@ -127,9 +127,9 @@
       actions: {
         items: [
           {
-            href: "#",
+            href: "./medical-information/other-medical-information" | urlWithReferrer(currentUrl, scrollTo),
             text: "Change",
-            visuallyHiddenText: "mammographer notes"
+            visuallyHiddenText: "other medical information"
           }
         ]
       } if allowEdits

--- a/app/views/events/medical-information/other-medical-information.html
+++ b/app/views/events/medical-information/other-medical-information.html
@@ -6,40 +6,33 @@
 
 {% set gridColumn = "nhsuk-grid-column-two-thirds" %}
 
+{% set formAction = './../record-medical-information' | getReturnUrl(referrerChain, query.scrollTo) %}
+
+
 {% block pageContent %}
 
-  {% set unit = data.breastScreeningUnits | findById(clinic.breastScreeningUnitId) %}
 
-  <form method="post" action="/clinics/{{ clinicId }}/events/{{ eventId }}/medical-information/other-medical-information/save">
-    <h1 class="nhsuk-heading-l">
-      <span class="nhsuk-caption-l">
-        {{ participant | getFullName }}
-      </span>
-      {{ pageHeading }}
-    </h1>
+  <h1 class="nhsuk-heading-l">
+    <span class="nhsuk-caption-l">
+      {{ participant | getFullName }}
+    </span>
+    {{ pageHeading }}
+  </h1>
 
-    {{ textarea({
-      name: "event[medicalInformation][mammographerNotes][notes]",
-      value: event.medicalInformation.mammographerNotes.notes,
-      hint: {
-        text: "Provide details of any relevant health conditions or medications that are not covered by symptoms or medical history questions."
-      },
-      rows: 15
-    }) }}
+  {{ textarea({
+    name: "event[medicalInformation][otherMedicalInformation]",
+    value: data.event.medicalInformation.otherMedicalInformation,
+    hint: {
+      text: "Provide details of any relevant health conditions or medications that are not covered by symptoms or medical history questions."
+    },
+    rows: 10
+  }) }}
 
-    {{ button({
-      text: "Save"
-    }) }}
-  </form>
+  {{ button({
+    text: "Save"
+  }) }}
 
-  {# Show delete option if notes exist #}
-  {% if event.medicalInformation.mammographerNotes.notes %}
-    <p class="nhsuk-u-margin-top-4">
-      <a href="{{ ('/clinics/' + clinicId + '/events/' + eventId + '/medical-information/other-medical-information/delete') | urlWithReferrer(referrerChain, scrollTo) }}" class="nhsuk-link app-link--warning">
-        Delete information
-      </a>
-    </p>
-  {% endif %}
+  
 
 
 {% endblock %}

--- a/app/views/events/medical-information/other-medical-information.html
+++ b/app/views/events/medical-information/other-medical-information.html
@@ -1,0 +1,45 @@
+{# app/views/events/medical-information/other-medical-information.html #}
+
+{% extends 'layout-app.html' %}
+
+{% set pageHeading = "Other medical information" %}
+
+{% set gridColumn = "nhsuk-grid-column-two-thirds" %}
+
+{% block pageContent %}
+
+  {% set unit = data.breastScreeningUnits | findById(clinic.breastScreeningUnitId) %}
+
+  <form method="post" action="/clinics/{{ clinicId }}/events/{{ eventId }}/medical-information/other-medical-information/save">
+    <h1 class="nhsuk-heading-l">
+      <span class="nhsuk-caption-l">
+        {{ participant | getFullName }}
+      </span>
+      {{ pageHeading }}
+    </h1>
+
+    {{ textarea({
+      name: "event[medicalInformation][mammographerNotes][notes]",
+      value: event.medicalInformation.mammographerNotes.notes,
+      hint: {
+        text: "Provide details of any relevant health conditions or medications that are not covered by symptoms or medical history questions."
+      },
+      rows: 15
+    }) }}
+
+    {{ button({
+      text: "Save"
+    }) }}
+  </form>
+
+  {# Show delete option if notes exist #}
+  {% if event.medicalInformation.mammographerNotes.notes %}
+    <p class="nhsuk-u-margin-top-4">
+      <a href="{{ ('/clinics/' + clinicId + '/events/' + eventId + '/medical-information/other-medical-information/delete') | urlWithReferrer(referrerChain, scrollTo) }}" class="nhsuk-link app-link--warning">
+        Delete information
+      </a>
+    </p>
+  {% endif %}
+
+
+{% endblock %}


### PR DESCRIPTION
- Adds other medical information section and page. 
- This allows mammographers to add medical information to a free-text box, which is situated at the very end of the medical information data collection page. 

<img width="692" height="792" alt="Screenshot 2025-09-26 at 14 52 37" src="https://github.com/user-attachments/assets/020c1e08-1761-4cd3-90ac-1b2791b6f2c8" />

