### PR TITLE
Persist section status during appointment

### DIFF
--- a/app/assets/javascript/expandable-sections.js
+++ b/app/assets/javascript/expandable-sections.js
@@ -54,6 +54,12 @@ document.addEventListener('DOMContentLoaded', function () {
         // Update the status for this section
         updateSectionStatus(section, newStatus)
 
+        // Save status to sessionStorage
+        const sectionId = section.getAttribute('id')
+        if (sectionId && window.saveSectionStatus) {
+          window.saveSectionStatus(sectionId, newStatus)
+        }
+
         // Close current section
         section.removeAttribute('open')
 

--- a/app/views/events/record-medical-information.html
+++ b/app/views/events/record-medical-information.html
@@ -35,7 +35,7 @@
     <div class="nhsuk-grid-column-two-thirds">
       {{ button({
         text: "Complete all and continue" if data.event.workflowStatus['record-medical-information'] != 'completed' else "Next section",
-        classes: "nhsuk-u-margin-bottom-0 nhsuk-button"
+        classes: "nhsuk-u-margin-bottom-0 nhsuk-button js-complete-all-sections"
       }) }}
 
     </div>
@@ -47,7 +47,8 @@
 
   <div class="nhsuk-form-group">
     {{ button({
-      text: "Complete all and continue"
+      text: "Complete all and continue",
+      classes: "js-complete-all-sections"
     }) }}
 
     {% include "screening-cannot-proceed-link.njk" %}


### PR DESCRIPTION
## Description
The status tags on the medical sections are done entirely in JS. This meant that if you left the page and returned, they reverted to their defaults. This updates to store the status in local storage so it's more realistic for users.

Also updates the 'Mark as reviewed' buttons once the statuses are updated.