### PR TITLE
Sept 30 bugfixes

### DIFF
--- a/app/data/test-scenarios.js
+++ b/app/data/test-scenarios.js
@@ -77,7 +77,7 @@ module.exports = [
         missingViews: ['RMLO', 'RCC'], // ensure all views are present
         scheduling: {
           whenRelativeToToday: 0,
-          status: 'event_checked_in',
+          status: 'event_scheduled',
           approximateTime: '11:30'
           // slotIndex: 20,
         }

--- a/app/lib/generators/event-generator.js
+++ b/app/lib/generators/event-generator.js
@@ -52,10 +52,10 @@ const determineEventStatus = (
   if (minutesPassed <= 60) {
     // Within 30 mins of appointment
     return weighted.select({
-      event_checked_in: 0.6,
-      event_complete: 0.1,
+      event_checked_in: 0.3,
+      event_complete: 0.2,
       event_attended_not_screened: 0.1,
-      event_scheduled: 0.2
+      event_scheduled: 0.4
     })
   } else {
     // More than 30 mins after appointment
@@ -82,6 +82,8 @@ const generateEvent = ({
   const simulatedDateTime = dayjs()
     .hour(parseInt(hours))
     .minute(parseInt(minutes))
+    .second(0)
+    .millisecond(0)
   const slotDateTime = dayjs(slot.dateTime)
   const isPast = slotDateTime.isBefore(simulatedDateTime)
 

--- a/app/views/_includes/summary-lists/rows/last-known-mammogram.njk
+++ b/app/views/_includes/summary-lists/rows/last-known-mammogram.njk
@@ -7,10 +7,10 @@
       <span class="nhsuk-u-font-weight-bold">At this BSU</span><br>
     {% endif %}
     {# Temporarily hardcode until we can investigate bug with date #}
-    {{ "2022-03-23" | formatDate }}
+    {# {{ "2022-03-23" | formatDate }}
     ({{ "2022-03-23" | formatDate | formatRelativeDate | asHint }})</br>
-    West of London BSU
-    {# {% set mostRecentClinic = data | getParticipantMostRecentClinic(participant.id) %}
+    West of London BSU #}
+    {% set mostRecentClinic = data | getParticipantMostRecentClinic(participant.id) %}
     {% if mostRecentClinic %}
       {{ mostRecentClinic | log }}
       {{ mostRecentClinic.event.timing.startTime | formatDate }} ({{ mostRecentClinic.event.timing.startTime | formatDate | formatRelativeDate | asHint }})</br>
@@ -19,7 +19,7 @@
 
     {% else %}
         {{ "Not known" | asHint }}
-    {% endif %} #}
+    {% endif %}
   </p>
 
   {% if hasAdditionalMammograms %}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -97,7 +97,7 @@ async function startNodemon(done) {
     stdout: true,
     ext: 'js json',
     watch: ['.env', 'app.js', 'app', 'lib'],
-    ignore: ['app/assets', '**.test.*'],
+    ignore: ['app/assets', 'app/data/generated', '**.test.*'],
     quiet: false
   })
 


### PR DESCRIPTION
## Description

Fixes for:
* Reduce number of checked-in people 
* Exclude generated data from nodemon watching (was preventing using data regeneration from the browser).
* Remove hardcoding of prior mammogram
* Ensure that test scenarios are reserved for today's clinic, not ones last week
* Prioritise existing participants in historic snapshots

Aside: The snapshot code is a bit awkward. It could probably do with being reworked to start with snapshots back in time, and slowly work forward adding participants. Not tackling that for now.