### PR TITLE
Suppress pointer events so tag is clickable

### DIFF
--- a/app/assets/sass/components/_details.scss
+++ b/app/assets/sass/components/_details.scss
@@ -12,6 +12,7 @@
   top: 0;
   right: 0;
   padding: 28px 32px 32px;
+  pointer-events: none;
 }
 
 .app-details__summary-subtitle {


### PR DESCRIPTION
## Description
In UR we've seen users try to click the 'to review' to expand the section.

We don't normally make tags clickable, but for the expanding details element, *everything* is clickable except the tag - which feels weird. This fixes it so the area is clickable.


<img width="2094" height="1258" alt="Screenshot 2025-10-01 at 11 23 42" src="https://github.com/user-attachments/assets/4934ba42-b0a2-42ca-ab6d-919f49114b6f" />
