### PR TITLE
Set form action so start appointment button works

### DIFF
--- a/app/views/_templates/layout-appointment-tab.html
+++ b/app/views/_templates/layout-appointment-tab.html
@@ -6,6 +6,8 @@
 
 {% set referrerChain = currentUrl %}
 
+{% set formAction = "./start" %}
+
 {% set back = {
   href: "/clinics/" + clinicId,
   text: "Back to clinic"


### PR DESCRIPTION
The 'start appointment' button didn't work if you were on the participant tab - because nothing was setting the form action.