### PR TITLE
Move appointment actions to main header and tweak sticky nav

### DIFF
--- a/app/views/_includes/appointment-header.njk
+++ b/app/views/_includes/appointment-header.njk
@@ -1,7 +1,7 @@
 {# app/views/_includes/event-active-header.njk #}
-
+{% include "_includes/appointment-status-bar.njk" %}
 <is-sticky class="app-appointment-header app-appointment-header--sticky">
-  {% include "_includes/appointment-status-bar.njk" %}
+  
 
   <div class="nhsuk-width-container">
     {% include "_includes/event-active-tabs.njk" %}

--- a/app/views/_includes/appointment-status-bar.njk
+++ b/app/views/_includes/appointment-status-bar.njk
@@ -1,9 +1,10 @@
 {# app/views/_includes/appointment-status-bar.njk #}
 
+
+{# Appointment actions - not currently used - moved to main header #}
 {% set leaveAppointmentLink %}
   <a href="{{ eventUrl }}/leave">Leave this appointment</a>
 {% endset %}
-
 
 {% set manageAppointmentLink %}
   <a href="#">Manage appointment</a>
@@ -18,37 +19,25 @@
   }
 ] %}
 
+{# Appointment row items - date, time, tags #}
 {% set appointmentRowItems = [] %}
 
-  {# Location name #}
-  {# {% set locationName %}
-    {% if location.type === 'mobile_unit' %}
-      {{ location.name }} at {{ clinic.siteName }}
-    {% else %}
-      {{ location.name }}
-    {% endif %}
-  {% endset %}
-  {% set appointmentRowItems = appointmentRowItems | push({
-    key: "Location:",
-    value: locationName
-  }) %} #}
+{# Date and time #}
+{% set appointmentHtml %}
+  {{ clinic.date | formatDate }} at {{ event.timing.startTime | formatTimeString }}
+  {% if event | isSpecialAppointment %}
+    {{ tag({
+      text: "Special appointment",
+      classes: "nhsuk-tag--yellow nhsuk-u-margin-left-1"
+    })}}
+  {% endif %}
+{% endset %}
+{% set appointmentRowItems = appointmentRowItems | push({
+  key: "Appointment:",
+  value: appointmentHtml
+}) %}
 
-  {# Date and time #}
-  {% set appointmentHtml %}
-    {{ clinic.date | formatDate }} at {{ event.timing.startTime | formatTimeString }}
-    {% if event | isSpecialAppointment %}
-      {{ tag({
-        text: "Special appointment",
-        classes: "nhsuk-tag--yellow nhsuk-u-margin-left-1"
-      })}}
-    {% endif %}
-  {% endset %}
-  {% set appointmentRowItems = appointmentRowItems | push({
-    key: "Appointment:",
-    value: appointmentHtml
-  }) %}
-
-  {# Appointment type #}
+{# Appointment type #}
 {% set screeningTagHtml %}
   <strong class="nhsuk-tag nhsuk-tag--blue">
     Screening
@@ -58,58 +47,57 @@
   html: screeningTagHtml
 }) %}
 
-  {% set statusHtml %}
-    {{ event.status | getStatusText | default(event.status | formatWords | sentenceCase) }}
+{% set statusHtml %}
+  {{ event.status | getStatusText | default(event.status | formatWords | sentenceCase) }}
 
-    {% if event | isSpecialAppointment %}
-    {# <br> #}
-      {{ tag({
-        text: "Special appointment",
-        classes: "nhsuk-tag--yellow nhsuk-u-margin-left-1"
-      })}}
-    {% endif %}
-  {% endset %}
+  {% if event | isSpecialAppointment %}
+  {# <br> #}
+    {{ tag({
+      text: "Special appointment",
+      classes: "nhsuk-tag--yellow nhsuk-u-margin-left-1"
+    })}}
+  {% endif %}
+{% endset %}
 
-  {# Appointment status #}
-  {# {% set appointmentRowItems = appointmentRowItems | push({
-    key: "Status:",
-    value: statusHtml
-  }) %} #}
+{# Appointment status #}
+{# {% set appointmentRowItems = appointmentRowItems | push({
+  key: "Status:",
+  value: statusHtml
+}) %} #}
 
-  {# Second row - participant details #}
-  {% set participantRowItems = [] %}
+{# Second row - participant name, dob, nhs number #}
+{% set participantRowItems = [] %}
 
-  {# Full name with age #}
-  {% set nameWithAge %}
-    {{ participant | getFullName }}
+{# Full name with age #}
+{% set nameWithAge %}
+  {{ participant | getFullName }}
 
-  {% endset %}
-  {% set participantRowItems = participantRowItems | push({
-    html: "<strong>" + nameWithAge + "</strong>"
-  }) %}
+{% endset %}
+{% set participantRowItems = participantRowItems | push({
+  html: "<strong>" + nameWithAge + "</strong>"
+}) %}
 
-  {% set dobValue %}
-    {{ participant.demographicInformation.dateOfBirth | formatDate }} {% if participant | getAge %}
-      ({{ participant | getAge }} years)
-    {% endif %}
-  {% endset %}
+{% set dobValue %}
+  {{ participant.demographicInformation.dateOfBirth | formatDate }} {% if participant | getAge %}
+    ({{ participant | getAge }} years)
+  {% endif %}
+{% endset %}
 
-  {# DOB #}
-  {% set participantRowItems = participantRowItems | push({
-    key: "DOB:",
-    value: dobValue
-  }) %}
+{# DOB #}
+{% set participantRowItems = participantRowItems | push({
+  key: "DOB:",
+  value: dobValue
+}) %}
 
-  {# NHS Number #}
-  {% set participantRowItems = participantRowItems | push({
-    key: "NHS:",
-    value: participant.medicalInformation.nhsNumber | formatNhsNumber
-  }) %}
+{# NHS Number #}
+{% set participantRowItems = participantRowItems | push({
+  key: "NHS:",
+  value: participant.medicalInformation.nhsNumber | formatNhsNumber
+}) %}
 
-  {{ appStatusBar({
-    rows: [
-      { items: appointmentActionItems },
-      { items: appointmentRowItems },
-      { items: participantRowItems }
-    ]
-  }) }}
+{{ appStatusBar({
+  rows: [
+    { items: appointmentRowItems },
+    { items: participantRowItems }
+  ]
+}) }}

--- a/app/views/_templates/layout-app.html
+++ b/app/views/_templates/layout-app.html
@@ -17,14 +17,67 @@
 {% block header %}
 
   {% set useMinimalNav = useMinimalNav | default(false) %}
+
   {% set rootHref = "/" %}
 
-  {% if event and event | isAppointmentWorkflow %}
-    {% set useMinimalNav = true %}
-
+  {% set appointmentWorkflow = event and event | isAppointmentWorkflow %}
+  {% if appointmentWorkflow %}
     {# Explicitly leave appointment if navigating away #}
-    {% set rootHref = eventUrl ~ "/leave" | urlWithReferrer("/") %}
+    {% set leaveAppointmentHref = eventUrl ~ "/leave" %}
+    {# Override rootHref so things don't get wrong when demoing #}
+    {% set rootHref = leaveAppointmentHref | urlWithReferrer("/") %}
   {% endif %}
+
+  {% set navItems = [
+    {
+      href: "/dashboard",
+      text: "Home",
+      current: true if navActive == "home"
+    },
+    {
+      href: "/clinics",
+      text: "Screening",
+      current: true if navActive == "screening"
+    },
+    {
+      href: "/reading",
+      text: "Image reading",
+      current: true if navActive == "reading"
+    },
+    {
+      href: "/participants",
+      text: "Participants",
+      current: true if navActive == "participants"
+    },
+    {
+      href: "#",
+      text: "Messages",
+      current: true if navActive == "messages"
+    }, {
+      href: "#",
+      text: "Help and support",
+      current: true if navActive == "help"
+    }
+  ] %}
+
+  {% if appointmentWorkflow %}
+    {% set navItems = [
+      {
+        href: leaveAppointmentHref,
+        text: "Leave this appointment"
+      },
+      {
+        href: "#",
+        text: "Manage appointment"
+      }
+    ] %}
+  {% endif %}
+
+  {# Used by error pages and some misc pages #}
+  {% if useMinimalNav %}
+    {% set navItems = [] %}
+  {% endif %}
+
 
   {{ header({
     account: {
@@ -45,38 +98,7 @@
       href: rootHref
     },
     navigation: {
-      items:
-      [
-        {
-          href: "/dashboard",
-          text: "Home",
-          current: true if navActive == "home"
-        },
-        {
-          href: "/clinics",
-          text: "Screening",
-          current: true if navActive == "screening"
-        },
-        {
-          href: "/reading",
-          text: "Image reading",
-          current: true if navActive == "reading"
-        },
-        {
-          href: "/participants",
-          text: "Participants",
-          current: true if navActive == "participants"
-        },
-        {
-          href: "#",
-          text: "Messages",
-          current: true if navActive == "messages"
-        }, {
-          href: "#",
-          text: "Help and support",
-          current: true if navActive == "help"
-        }
-      ] if not useMinimalNav
+      items: navItems
     }
   }) }}
  {#  {{ serviceheader({


### PR DESCRIPTION
## Description
Tweaks the sticky header from the appointment nav to:

* Put appointment actions in the main header, not secondary status bar
* Only include the tabs in the sticky bit

I wasn't wholly comfortable with how much this had diverged from the design system, so this is partly paring back some of the changes to try to find a middle ground.

After
![manage-sticky-header-mk2](https://github.com/user-attachments/assets/5deb2225-090e-4d44-9f56-3030fe3c89e1)

Before
![manage-sticky-header-mk1](https://github.com/user-attachments/assets/59993f86-cc01-4085-92c8-bcd5b1ec63d9)
